### PR TITLE
PrisonerLocation model and endpoint

### DIFF
--- a/mtp_api/apps/core/tests/utils.py
+++ b/mtp_api/apps/core/tests/utils.py
@@ -26,10 +26,10 @@ def make_test_oauth_applications():
     )
 
     Application.objects.get_or_create(
-        client_id='noms-admin',
+        client_id='prisoner-location-admin',
         client_type='confidential',
         authorization_grant_type='password',
-        client_secret='noms-admin',
-        name='noms-admin',
+        client_secret='prisoner-location-admin',
+        name='prisoner-location-admin',
         user=User.objects.first()
     )

--- a/mtp_api/apps/core/tests/utils.py
+++ b/mtp_api/apps/core/tests/utils.py
@@ -1,7 +1,9 @@
-from django.contrib.auth.models import User
-from mtp_auth.tests.mommy_recipes import create_prison_user_mapping
 from oauth2_provider.models import Application
+
+from django.contrib.auth.models import User
+
 from prison.models import Prison
+from mtp_auth.tests.mommy_recipes import create_prison_user_mapping
 
 
 def make_test_users(users_per_prison=1):
@@ -20,4 +22,14 @@ def make_test_oauth_applications():
         authorization_grant_type='password',
         client_secret='cashbook',
         name='cashbook',
-        user=User.objects.first())
+        user=User.objects.first()
+    )
+
+    Application.objects.get_or_create(
+        client_id='noms-admin',
+        client_type='confidential',
+        authorization_grant_type='password',
+        client_secret='noms-admin',
+        name='noms-admin',
+        user=User.objects.first()
+    )

--- a/mtp_api/apps/prison/migrations/0002_prisonerlocation.py
+++ b/mtp_api/apps/prison/migrations/0002_prisonerlocation.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import model_utils.fields
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('prison', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PrisonerLocation',
+            fields=[
+                ('id', models.AutoField(serialize=False, auto_created=True, primary_key=True, verbose_name='ID')),
+                ('created', model_utils.fields.AutoCreatedField(editable=False, default=django.utils.timezone.now, verbose_name='created')),
+                ('modified', model_utils.fields.AutoLastModifiedField(editable=False, default=django.utils.timezone.now, verbose_name='modified')),
+                ('upload_counter', models.PositiveIntegerField()),
+                ('prisoner_number', models.CharField(max_length=250)),
+                ('prisoner_dob', models.DateField()),
+                ('created_by', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('prison', models.ForeignKey(to='prison.Prison')),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+    ]

--- a/mtp_api/apps/prison/migrations/0003_remove_prisonerlocation_upload_counter.py
+++ b/mtp_api/apps/prison/migrations/0003_remove_prisonerlocation_upload_counter.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('prison', '0002_prisonerlocation'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='prisonerlocation',
+            name='upload_counter',
+        ),
+    ]

--- a/mtp_api/apps/prison/models.py
+++ b/mtp_api/apps/prison/models.py
@@ -19,10 +19,3 @@ class PrisonerLocation(TimeStampedModel):
     prisoner_dob = models.DateField()
 
     prison = models.ForeignKey(Prison)
-
-    def __str__(self):
-        return 'location record ' \
-            'for prisoner {prisoner_number} / {prisoner_dob}'.format(
-                prisoner_number=self.prisoner_number,
-                prisoner_dob=self.prisoner_dob
-            )

--- a/mtp_api/apps/prison/models.py
+++ b/mtp_api/apps/prison/models.py
@@ -13,7 +13,6 @@ class Prison(TimeStampedModel):
 
 
 class PrisonerLocation(TimeStampedModel):
-    upload_counter = models.PositiveIntegerField()
     created_by = models.ForeignKey(settings.AUTH_USER_MODEL)
 
     prisoner_number = models.CharField(max_length=250)
@@ -22,9 +21,8 @@ class PrisonerLocation(TimeStampedModel):
     prison = models.ForeignKey(Prison)
 
     def __str__(self):
-        return 'location record {upload_counter} ' \
+        return 'location record ' \
             'for prisoner {prisoner_number} / {prisoner_dob}'.format(
-                upload_counter=self.upload_counter,
                 prisoner_number=self.prisoner_number,
                 prisoner_dob=self.prisoner_dob
             )

--- a/mtp_api/apps/prison/models.py
+++ b/mtp_api/apps/prison/models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import models
 
 from model_utils.models import TimeStampedModel
@@ -9,3 +10,21 @@ class Prison(TimeStampedModel):
 
     def __str__(self):
         return self.name
+
+
+class PrisonerLocation(TimeStampedModel):
+    upload_counter = models.PositiveIntegerField()
+    created_by = models.ForeignKey(settings.AUTH_USER_MODEL)
+
+    prisoner_number = models.CharField(max_length=250)
+    prisoner_dob = models.DateField()
+
+    prison = models.ForeignKey(Prison)
+
+    def __str__(self):
+        return 'location record {upload_counter} ' \
+            'for prisoner {prisoner_number} / {prisoner_dob}'.format(
+                upload_counter=self.upload_counter,
+                prisoner_number=self.prisoner_number,
+                prisoner_dob=self.prisoner_dob
+            )

--- a/mtp_api/apps/prison/serializers.py
+++ b/mtp_api/apps/prison/serializers.py
@@ -1,0 +1,34 @@
+from django.db.models import Max
+
+from rest_framework import serializers
+
+from .models import PrisonerLocation
+
+
+class PrisonerLocationListSerializer(serializers.ListSerializer):
+
+    def get_latest_upload_counter(self):
+        result = PrisonerLocation.objects.all().aggregate(max=Max('upload_counter'))
+        return result['max'] or 0
+
+    def create(self, validated_data):
+        # NOTE: this can cause race conditions and can be fixed but do we care?
+        # Not likely to happen
+        next_upload_counter = self.get_latest_upload_counter() + 1
+
+        locations = [
+            PrisonerLocation(upload_counter=next_upload_counter, **item) for item in validated_data
+        ]
+        return PrisonerLocation.objects.bulk_create(locations)
+
+
+class PrisonerLocationSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = PrisonerLocation
+        list_serializer_class = PrisonerLocationListSerializer
+        fields = (
+            'prisoner_number',
+            'prisoner_dob',
+            'prison',
+        )

--- a/mtp_api/apps/prison/serializers.py
+++ b/mtp_api/apps/prison/serializers.py
@@ -1,4 +1,3 @@
-from django.db.models import Max
 from django.db import transaction
 
 from rest_framework import serializers

--- a/mtp_api/apps/prison/tests/test_views.py
+++ b/mtp_api/apps/prison/tests/test_views.py
@@ -14,7 +14,7 @@ from prison.tests.utils import random_prisoner_number, random_prisoner_dob
 
 
 class PrisonerLocationViewTestCase(APITestCase):
-    fixtures = ['test_prisons.json']
+    fixtures = ['test_prisons.json', 'initial_groups.json']
 
     def setUp(self):
         super(PrisonerLocationViewTestCase, self).setUp()

--- a/mtp_api/apps/prison/tests/test_views.py
+++ b/mtp_api/apps/prison/tests/test_views.py
@@ -1,0 +1,124 @@
+from model_mommy import mommy
+
+from django.core.urlresolvers import reverse
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from core.tests.utils import make_test_users, \
+    make_test_oauth_applications
+
+from prison.models import Prison, PrisonerLocation
+
+from prison.tests.utils import random_prisoner_number, random_prisoner_dob
+
+
+class PrisonerLocationViewTestCase(APITestCase):
+    fixtures = ['test_prisons.json']
+
+    def setUp(self):
+        super(PrisonerLocationViewTestCase, self).setUp()
+        self.users = make_test_users()
+        self.prisons = Prison.objects.all()
+        make_test_oauth_applications()
+
+    @property
+    def list_url(self):
+        return reverse('prisonerlocation-list')
+
+    def test_cannot_create_if_not_logged_in(self):
+        response = self.client.post(
+            self.list_url, format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_create(self):
+        user = self.users[0]
+
+        # create one PrisonerLocation so that we test the upload_counter
+        # increment
+        mommy.make(PrisonerLocation, upload_counter=1)
+        self.assertEqual(PrisonerLocation.objects.count(), 1)
+
+        self.client.force_authenticate(user=user)
+
+        data = [
+            {
+                'prisoner_number': random_prisoner_number(),
+                'prisoner_dob': random_prisoner_dob(),
+                'prison': self.prisons[0].pk
+            },
+            {
+                'prisoner_number': random_prisoner_number(),
+                'prisoner_dob': random_prisoner_dob(),
+                'prison': self.prisons[1].pk
+            },
+        ]
+        response = self.client.post(
+            self.list_url, data=data, format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # test that 2 prisoner location records got created
+        latest_created = PrisonerLocation.objects.filter(upload_counter=2)
+        self.assertEqual(latest_created.count(), len(data))
+        for item in data:
+            self.assertEqual(latest_created.filter(**item).count(), 1)
+
+    def test_create_validation_error(self):
+        user = self.users[0]
+
+        invalid_data_list = [
+            {
+                'data': {},
+                'msg': 'Should fail because invalid format (dict instead of list)'
+            },
+            {
+                'data': [
+                    {}
+                ],
+                'msg': 'Should fail because empty data'
+            },
+            {
+                'data': [
+                    {
+                        'prisoner_number': '*'*1000,
+                        'prisoner_dob': random_prisoner_dob(),
+                        'prison': self.prisons[0].pk
+                    }
+                ],
+                'msg': 'Should fail because empty data'
+            },
+            {
+                'data': [
+                    {
+                        'prisoner_number': random_prisoner_number(),
+                        'prisoner_dob': '01//02//2015',
+                        'prison': self.prisons[0].pk
+                    }
+                ],
+                'msg': 'Should fail because invalid data format'
+            },
+            {
+                'data': [
+                    {
+                        'prisoner_number': random_prisoner_number(),
+                        'prisoner_dob': random_prisoner_dob(),
+                        'prison': 'invalid'
+                    }
+                ],
+                'msg': 'Should fail because invalid prison'
+            },
+        ]
+
+        self.client.force_authenticate(user=user)
+
+        for data in invalid_data_list:
+            response = self.client.post(
+                self.list_url, data=data['data'], format='json'
+            )
+            self.assertEqual(
+                response.status_code,
+                status.HTTP_400_BAD_REQUEST,
+                'Should fail because: {msg}'.format(msg=data['msg'])
+            )

--- a/mtp_api/apps/prison/tests/utils.py
+++ b/mtp_api/apps/prison/tests/utils.py
@@ -1,0 +1,22 @@
+import datetime
+import random
+import string
+
+from django.utils.crypto import get_random_string
+
+
+def random_prisoner_dob():
+    return datetime.date(
+        day=random.randint(1, 28),
+        month=random.randint(1, 12),
+        year=random.randint(1930, 1990)
+    )
+
+
+def random_prisoner_number():
+    # format: [A-Z]\d{4}[A-Z]{2}
+    return '%s%s%s' % (
+        get_random_string(allowed_chars=string.ascii_uppercase, length=1),
+        get_random_string(allowed_chars=string.digits, length=4),
+        get_random_string(allowed_chars=string.ascii_uppercase, length=2)
+    )

--- a/mtp_api/apps/prison/views.py
+++ b/mtp_api/apps/prison/views.py
@@ -1,1 +1,28 @@
+from rest_framework import mixins, viewsets, status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
+from .models import PrisonerLocation
+from .serializers import PrisonerLocationSerializer
+
+
+class PrisonerLocationView(
+    mixins.CreateModelMixin, viewsets.GenericViewSet,
+):
+    queryset = PrisonerLocation.objects.all()
+
+    permission_classes = (IsAuthenticated, )
+    serializer_class = PrisonerLocationSerializer
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data, many=True)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+
+        return Response(
+            serializer.data, status=status.HTTP_201_CREATED, headers=headers
+        )
+
+    def perform_create(self, serializer):
+        serializer.save(created_by=self.request.user)

--- a/mtp_api/apps/transaction/tests/utils.py
+++ b/mtp_api/apps/transaction/tests/utils.py
@@ -1,6 +1,5 @@
 import datetime
 import random
-import string
 
 from django.utils import timezone
 from django.utils.crypto import get_random_string
@@ -11,21 +10,7 @@ from transaction.models import Transaction
 from transaction.constants import TRANSACTION_STATUS
 
 
-def random_dob():
-    return datetime.date(
-        day=random.randint(1, 28),
-        month=random.randint(1, 12),
-        year=random.randint(1930, 1990)
-    )
-
-
-def random_prison_number():
-    # format: [A-Z]\d{4}[A-Z]{2}
-    return '%s%s%s' % (
-        get_random_string(allowed_chars=string.ascii_uppercase, length=1),
-        get_random_string(allowed_chars=string.digits, length=4),
-        get_random_string(allowed_chars=string.ascii_uppercase, length=2)
-    )
+from prison.tests.utils import random_prisoner_number, random_prisoner_dob
 
 
 def random_reference(prisoner_number=None, prisoner_dob=None):
@@ -95,8 +80,8 @@ def generate_transactions(uploads=2, transaction_batch=30):
                 prison = prison_chooser.choose_prison()
                 data.update({
                     'prison': prison,
-                    'prisoner_number': random_prison_number(),
-                    'prisoner_dob': random_dob()
+                    'prisoner_number': random_prisoner_number(),
+                    'prisoner_dob': random_prisoner_dob()
                 })
 
                 # randomly choose the state of the transaction

--- a/mtp_api/urls.py
+++ b/mtp_api/urls.py
@@ -6,12 +6,14 @@ from django.views.generic.base import TemplateView
 from rest_framework import routers
 
 from mtp_auth.views import UserViewSet
+from prison.views import PrisonerLocationView
 from transaction.routers import TransactionRouter
 
 transaction_router = TransactionRouter()
 
 router = routers.DefaultRouter()
 router.register(r'users', UserViewSet)
+router.register(r'prisoner-locations', PrisonerLocationView)
 
 urlpatterns = patterns(
     '',


### PR DESCRIPTION
New endpoint allowing the creation of multiple prisoner locations at the same time.
This simulates a report upload but it's a lot cleaner/easier to understand and safer.

The format is:

    CREATE   /prisoner-locations/
        [
        	{
        		prisoner_number: "<prisoner-number>",  # e.g. L2513UV
        		prisoner_dob: "<prisoner-dob>",  # e.g. 1980-06-17
        		prison: "<prison-id>"  # e.g. prison-1
        	},
        	{
        		prisoner_number: "<prisoner-number>",  # e.g. L2513UV
        		prisoner_dob: "<prisoner-dob>",  # e.g. 1980-06-17
        		prison: "<prison-id>"  # e.g. prison-1
        	}
        ]  

The system would store the items and update an `upload_counter` incremented field on each one of them which can be used later on to group them.

**Pros**
 * easy to understand
 * we don't need to store any files

**Cons**
 * clients would have to pre-process the data
 * each call to the endpoint represents an "upload" so partial creates are not allowed (2 calls => 2 uploads with the last one meant to "override" the first one).