### PR TITLE
Add permission checks to transaction endpoints

### DIFF
--- a/mtp_api/apps/core/management/commands/load_test_data.py
+++ b/mtp_api/apps/core/management/commands/load_test_data.py
@@ -1,5 +1,7 @@
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
+from django.contrib.auth.models import User
+
 from core.tests.utils import make_test_users, \
     make_test_oauth_applications
 
@@ -13,5 +15,8 @@ class Command(BaseCommand):
             'test_transactions.json',
             'initial_groups.json'
         )
+
+        User.objects.all().delete()
         make_test_users()
+
         make_test_oauth_applications()

--- a/mtp_api/apps/core/permissions.py
+++ b/mtp_api/apps/core/permissions.py
@@ -1,0 +1,13 @@
+from rest_framework.permissions import DjangoModelPermissions
+
+
+class FullDjangoModelPermissions(DjangoModelPermissions):
+    perms_map = {
+        'GET': ['%(app_label)s.view_%(model_name)s'],
+        'OPTIONS': [],
+        'HEAD': [],
+        'POST': ['%(app_label)s.add_%(model_name)s'],
+        'PUT': ['%(app_label)s.change_%(model_name)s'],
+        'PATCH': ['%(app_label)s.change_%(model_name)s'],
+        'DELETE': ['%(app_label)s.delete_%(model_name)s'],
+    }

--- a/mtp_api/apps/mtp_auth/fixtures/initial_groups.json
+++ b/mtp_api/apps/mtp_auth/fixtures/initial_groups.json
@@ -20,7 +20,11 @@
   "pk": 3,
   "fields": {
     "name": "PrisonClerk",
-    "permissions": []
+    "permissions": [
+      ["view_transaction", "transaction", "transaction"],
+      ["add_transaction", "transaction", "transaction"],
+      ["change_transaction", "transaction", "transaction"]
+    ]
   }
 }
 ]

--- a/mtp_api/apps/mtp_auth/tests/mommy_recipes.py
+++ b/mtp_api/apps/mtp_auth/tests/mommy_recipes.py
@@ -2,7 +2,7 @@ from model_mommy import timezone
 from model_mommy.mommy import make
 from model_mommy.recipe import Recipe, foreign_key
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group
 from django.utils.text import slugify
 from django.utils.crypto import get_random_string
 
@@ -23,6 +23,7 @@ prison_user_mapping = Recipe(PrisonUserMapping,
 
 
 def create_prison_user_mapping(prison):
+    prison_clerk_group = Group.objects.get(name='PrisonClerk')
     name_and_password = 'test_' + slugify(prison).replace('-', '_')
 
     # if first user
@@ -41,4 +42,5 @@ def create_prison_user_mapping(prison):
     )
     pu.user.set_password(name_and_password)
     pu.user.save()
+    pu.user.groups.add(prison_clerk_group)
     return pu

--- a/mtp_api/apps/mtp_auth/tests/test_views.py
+++ b/mtp_api/apps/mtp_auth/tests/test_views.py
@@ -9,7 +9,10 @@ from prison.models import Prison
 
 
 class UserViewTestCase(APITestCase):
-    fixtures = ['test_prisons.json']
+    fixtures = [
+        'initial_groups.json',
+        'test_prisons.json'
+    ]
 
     def setUp(self):
         super(UserViewTestCase, self).setUp()

--- a/mtp_api/apps/transaction/migrations/0005_auto_20150727_1610.py
+++ b/mtp_api/apps/transaction/migrations/0005_auto_20150727_1610.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transaction', '0004_log'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='transaction',
+            options={'permissions': (('view_transaction', 'Can view transaction'),), 'ordering': ('received_at',)},
+        ),
+    ]

--- a/mtp_api/apps/transaction/models.py
+++ b/mtp_api/apps/transaction/models.py
@@ -68,6 +68,7 @@ class Transaction(TimeStampedModel):
 
     class Meta:
         ordering = ('received_at',)
+        permissions = (("view_transaction", "Can view transaction"),)
 
 
 class Log(TimeStampedModel):

--- a/mtp_api/apps/transaction/tests/test_views.py
+++ b/mtp_api/apps/transaction/tests/test_views.py
@@ -27,7 +27,10 @@ def get_prisons_for_user(user):
 
 
 class BaseTransactionViewTestCase(APITestCase):
-    fixtures = ['test_prisons.json']
+    fixtures = [
+        'initial_groups.json',
+        'test_prisons.json'
+    ]
     STATUS_FILTERS = {
         None: lambda t: True,
         TRANSACTION_STATUS.PENDING: lambda t: t.owner and not t.credited,
@@ -143,6 +146,25 @@ class TransactionsByPrisonEndpointTestCase(BaseTransactionViewTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_fails_without_permissions(self):
+        """
+        Tests that logged-in user has to have the right permissions
+        to access the endpoint.
+        """
+        prison = self.prisons[0]
+        user = get_users_for_prison(prison)[0]
+
+        # delete user from groups
+        user.groups.all().delete()
+
+        url = self._get_list_url(prison)
+
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     def test_all(self):
         """
         GET without params should return all transactions linked
@@ -230,6 +252,25 @@ class TransactionsByPrisonAndUserEndpointTestCase(BaseTransactionViewTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_fails_without_permissions(self):
+        """
+        Tests that logged-in user has to have the right permissions
+        to access the endpoint.
+        """
+        prison = self.prisons[0]
+        user = get_users_for_prison(prison)[0]
+
+        # delete user from groups
+        user.groups.all().delete()
+
+        url = self._get_list_url(user, prison)
+
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     def test_all(self):
         self._request_and_assert()
 
@@ -263,6 +304,25 @@ class TransactionsTakeTestCase(BaseTransactionViewTestCase):
             url += '?count={count}'.format(count=count)
 
         return url
+
+    def test_fails_without_permissions(self):
+        """
+        Tests that logged-in user has to have the right permissions
+        to access the endpoint.
+        """
+        prison = self.prisons[0]
+        user = get_users_for_prison(prison)[0]
+
+        # delete user from groups
+        user.groups.all().delete()
+
+        url = self._get_url(user, prison)
+
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_take_within_limit(self):
         """
@@ -398,6 +458,25 @@ class TransactionsReleaseTestCase(BaseTransactionViewTestCase):
                 'prison_id': prison.pk
             }
         )
+
+    def test_fails_without_permissions(self):
+        """
+        Tests that logged-in user has to have the right permissions
+        to access the endpoint.
+        """
+        prison = self.prisons[0]
+        user = get_users_for_prison(prison)[0]
+
+        # delete user from groups
+        user.groups.all().delete()
+
+        url = self._get_url(user, prison)
+
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_cannot_release_somebody_else_s_transactions_in_different_prison(self):
         """
@@ -586,7 +665,7 @@ class TransactionsReleaseTestCase(BaseTransactionViewTestCase):
         )
 
 
-class TransactionsPathTestCase(BaseTransactionViewTestCase):
+class TransactionsPatchTestCase(BaseTransactionViewTestCase):
 
     def _get_url(self, user, prison):
         return reverse(
@@ -595,6 +674,25 @@ class TransactionsPathTestCase(BaseTransactionViewTestCase):
                 'prison_id': prison.pk
             }
         )
+
+    def test_fails_without_permissions(self):
+        """
+        Tests that logged-in user has to have the right permissions
+        to access the endpoint.
+        """
+        prison = self.prisons[0]
+        user = get_users_for_prison(prison)[0]
+
+        # delete user from groups
+        user.groups.all().delete()
+
+        url = self._get_url(user, prison)
+
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_cannot_patch_somebody_else_s_transactions(self):
         """

--- a/mtp_api/apps/transaction/tests/test_views.py
+++ b/mtp_api/apps/transaction/tests/test_views.py
@@ -70,7 +70,7 @@ class BaseTransactionViewTestCase(APITestCase):
         )
 
 
-class TransactionPermissionTestMixin(object):
+class TransactionRejectsRequestsWithoutPermissionTestMixin(object):
 
     """
     Mixin for permission checks on the endpoint.
@@ -118,7 +118,7 @@ class TransactionsEndpointTestCase(BaseTransactionViewTestCase):
 
 
 class TransactionsByPrisonEndpointTestCase(
-    TransactionPermissionTestMixin, BaseTransactionViewTestCase
+    TransactionRejectsRequestsWithoutPermissionTestMixin, BaseTransactionViewTestCase
 ):
 
     def _request_and_assert(self, status_param=None):
@@ -203,7 +203,7 @@ class TransactionsByPrisonEndpointTestCase(
 
 
 class TransactionsByPrisonAndUserEndpointTestCase(
-    TransactionPermissionTestMixin, BaseTransactionViewTestCase
+    TransactionRejectsRequestsWithoutPermissionTestMixin, BaseTransactionViewTestCase
 ):
 
     def _request_and_assert(self, status_param=None):
@@ -288,7 +288,7 @@ class TransactionsByPrisonAndUserEndpointTestCase(
 
 
 class TransactionsTakeTestCase(
-    TransactionPermissionTestMixin, BaseTransactionViewTestCase
+    TransactionRejectsRequestsWithoutPermissionTestMixin, BaseTransactionViewTestCase
 ):
     ENDPOINT_VERB = 'post'
 
@@ -431,7 +431,7 @@ class TransactionsTakeTestCase(
 
 
 class TransactionsReleaseTestCase(
-    TransactionPermissionTestMixin, BaseTransactionViewTestCase
+    TransactionRejectsRequestsWithoutPermissionTestMixin, BaseTransactionViewTestCase
 ):
     ENDPOINT_VERB = 'post'
 
@@ -631,7 +631,7 @@ class TransactionsReleaseTestCase(
 
 
 class TransactionsPatchTestCase(
-    TransactionPermissionTestMixin, BaseTransactionViewTestCase
+    TransactionRejectsRequestsWithoutPermissionTestMixin, BaseTransactionViewTestCase
 ):
     ENDPOINT_VERB = 'patch'
 

--- a/mtp_api/apps/transaction/views.py
+++ b/mtp_api/apps/transaction/views.py
@@ -1,14 +1,17 @@
+import django_filters
+
 from django.db import transaction
 from django.http import HttpResponseRedirect
 
-import django_filters
 from rest_framework import mixins, viewsets, filters, status, exceptions
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
+from core.permissions import FullDjangoModelPermissions
 from mtp_auth.models import PrisonUserMapping
 from prison.models import Prison
+
 from .models import Transaction
 from .serializers import TransactionSerializer, \
     CreditedOnlyTransactionSerializer
@@ -26,6 +29,7 @@ class StatusChoiceFilter(django_filters.ChoiceFilter):
 
         qs = qs.filter(**qs.model.STATUS_LOOKUP[value.lower()])
         return qs
+
 
 class TransactionStatusFilter(django_filters.FilterSet):
 
@@ -63,7 +67,9 @@ class TransactionView(
     filter_class = TransactionStatusFilter
 
     ordering = ('received_at',)
-    permission_classes = (IsAuthenticated, IsOwnPrison,)
+    permission_classes = (
+        IsAuthenticated, IsOwnPrison, FullDjangoModelPermissions
+    )
 
     def get_queryset(self, filter_by_user=True, filter_by_prison=True):
         qs = super(TransactionView, self).get_queryset()


### PR DESCRIPTION
So that only users with the right permissions can access the transaction endpoints.
Done by using Django permissions + DRF Django Permission class.
I had to subclass the latter to support permission checks on GETs as not enabled by default.

We will use Django groups (Prison Clerk in this case) to manage these permissions.