### PR TITLE
Make DB name configurable for use in devenvs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ django:
   links:
     - db
   environment:
+    DB_NAME: postgres
     DB_USERNAME: postgres
     DB_PASSWORD: postgres
     DB_HOST: db_1

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -139,7 +139,7 @@ TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'mtp_api',
+        'NAME': os.environ.get('DB_NAME', 'mtp_api'),
         'USER': os.environ.get('DB_USERNAME', 'postgres'),
         'PASSWORD': os.environ.get('DB_PASSWORD', ''),
         'HOST': os.environ.get('DB_HOST', ''),                      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.


### PR DESCRIPTION
At present, we have to manually initialise the containers' `mtp_api` database, but the postgres image we're using for our database comes with a pre-configured `postgres` database.

[The documentation](https://registry.hub.docker.com/_/postgres/) says this database is “meant for use by users, utilities and third party applications”. Given that docker-compose is only used for development/testing, we probably don't need a dedicated new DB created, so we can just use the default postgres DB in Django.

I also tried setting a `POSTGRES_DB` environment variable and [letting the postgres container's entrypoint set up the database](https://github.com/docker-library/postgres/blob/master/9.4/docker-entrypoint.sh#L64), but the new DB doesn't appear to be ready in time for the django container to run migrations et al.