### PR TITLE
Refactor permission checking

### DIFF
--- a/mtp_api/apps/core/permissions.py
+++ b/mtp_api/apps/core/permissions.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import ImproperlyConfigured
+
 from rest_framework.compat import get_model_name
 from rest_framework.permissions import BasePermission
 
@@ -24,6 +26,8 @@ class ActionsBasedPermissions(BasePermission):
     as it's based on actions instead of methods.
     A `POST` that creates a resource and one that makes an action on a resource
     usually have different permissions so they should be treated differently.
+
+    NOTE: This is only meant to work with ViewSets.
     """
 
     # Map methods into required permission codes.
@@ -56,6 +60,10 @@ class ActionsBasedPermissions(BasePermission):
         return [perm % kwargs for perm in self.actions_perms_map[action]]
 
     def has_permission(self, request, view):
+        if not hasattr(view, 'action'):
+            msg = ("Can only use %s on a ViewSet")
+            raise ImproperlyConfigured(msg % self.__class__.__name__)
+
         # Workaround to ensure DjangoModelPermissions are not applied
         # to the root view when using DefaultRouter.
         if getattr(view, '_ignore_model_permissions', False):

--- a/mtp_api/apps/core/permissions.py
+++ b/mtp_api/apps/core/permissions.py
@@ -1,13 +1,80 @@
-from rest_framework.permissions import DjangoModelPermissions
+from rest_framework.compat import get_model_name
+from rest_framework.permissions import BasePermission
 
 
-class FullDjangoModelPermissions(DjangoModelPermissions):
-    perms_map = {
-        'GET': ['%(app_label)s.view_%(model_name)s'],
-        'OPTIONS': [],
-        'HEAD': [],
-        'POST': ['%(app_label)s.add_%(model_name)s'],
-        'PUT': ['%(app_label)s.change_%(model_name)s'],
-        'PATCH': ['%(app_label)s.change_%(model_name)s'],
-        'DELETE': ['%(app_label)s.delete_%(model_name)s'],
+class ActionsBasedPermissions(BasePermission):
+    """
+    The request is authenticated using `django.contrib.auth` permissions.
+    See: https://docs.djangoproject.com/en/dev/topics/auth/#permissions
+
+    It ensures that the user is authenticated, and has the appropriate
+    `add`/`change`/`delete` permissions on the model.
+
+    This permission can only be applied against view classes that
+    provide a `.queryset` attribute.
+
+    Permission mapping is defined against view actions ('list', 'retrieve',
+    'update', 'destroy' etc.).
+    When using custom actions on a view, you would have to add a new
+    (key, value) to the mapping and set the permissions you want the class
+    to test against.
+
+    This version is slightly better than the
+    `rest_framework.permissions.DjangoModelPermissions` one in our use case
+    as it's based on actions instead of methods.
+    A `POST` that creates a resource and one that makes an action on a resource
+    usually have different permissions so they should be treated differently.
+    """
+
+    # Map methods into required permission codes.
+    # Override this if you need to also provide 'view' permissions,
+    # or if you want to provide custom permission codes.
+    actions_perms_map = {
+        'create': ['%(app_label)s.add_%(model_name)s'],
+        'list': [],
+        'retrieve': [],
+        'update': ['%(app_label)s.change_%(model_name)s'],
+        'partial_update': ['%(app_label)s.change_%(model_name)s'],
+        'destroy': ['%(app_label)s.delete_%(model_name)s']
     }
+
+    authenticated_users_only = True
+
+    def get_required_permissions(self, action, model_cls):
+        """
+        Given a model and an HTTP method, return the list of permission
+        codes that the user is required to have.
+        """
+        kwargs = {
+            'app_label': model_cls._meta.app_label,
+            'model_name': get_model_name(model_cls)
+        }
+
+        # This line raises KeyError if you add a custom action to
+        # the view and you forget to add it to the actions_perms_map as
+        # well. This is on purpose :-)
+        return [perm % kwargs for perm in self.actions_perms_map[action]]
+
+    def has_permission(self, request, view):
+        # Workaround to ensure DjangoModelPermissions are not applied
+        # to the root view when using DefaultRouter.
+        if getattr(view, '_ignore_model_permissions', False):
+            return True
+
+        try:
+            queryset = view.get_queryset()
+        except AttributeError:
+            queryset = getattr(view, 'queryset', None)
+
+        assert queryset is not None, (
+            'Cannot apply DjangoModelPermissions on a view that '
+            'does not have `.queryset` property or overrides the '
+            '`.get_queryset()` method.')
+
+        perms = self.get_required_permissions(view.action, queryset.model)
+
+        return (
+            request.user and
+            (request.user.is_authenticated() or not self.authenticated_users_only) and
+            request.user.has_perms(perms)
+        )

--- a/mtp_api/apps/core/tests/test_permissions.py
+++ b/mtp_api/apps/core/tests/test_permissions.py
@@ -1,0 +1,206 @@
+import base64
+
+from django.test import TestCase
+from django.contrib.auth.models import Group, Permission, User
+from django.core.exceptions import ImproperlyConfigured
+
+from rest_framework import (
+    HTTP_HEADER_ENCODING, authentication, serializers, generics,
+    status, mixins, viewsets
+)
+from rest_framework.test import APIRequestFactory
+
+from core.permissions import ActionsBasedPermissions
+
+
+factory = APIRequestFactory()
+
+
+class GroupSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Group
+        fields = ('name',)
+
+
+class TestViewSet(
+    mixins.CreateModelMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet
+):
+    queryset = Group.objects.all()
+    serializer_class = GroupSerializer
+    authentication_classes = [authentication.BasicAuthentication]
+    permission_classes = [ActionsBasedPermissions]
+
+
+def basic_auth_header(username, password):
+    credentials = ('%s:%s' % (username, password))
+    base64_credentials = base64.b64encode(credentials.encode(HTTP_HEADER_ENCODING)).decode(HTTP_HEADER_ENCODING)
+    return 'Basic %s' % base64_credentials
+
+
+class BaseActionsBasedPermissionsTests(TestCase):
+
+    def setUp(self):
+        User.objects.create_user('disallowed', 'disallowed@example.com', 'password')
+        user = User.objects.create_user('permitted', 'permitted@example.com', 'password')
+        user.user_permissions = [
+            Permission.objects.get(codename='add_group'),
+            Permission.objects.get(codename='change_group'),
+            Permission.objects.get(codename='delete_group')
+        ]
+
+        self.permitted_credentials = basic_auth_header('permitted', 'password')
+        self.disallowed_credentials = basic_auth_header('disallowed', 'password')
+
+        self.group = Group.objects.create(name='foo')
+
+        self.test_view = self._get_test_view()
+
+    def _get_test_view(self):
+        raise NotImplementedError()
+
+
+class CreateActionsBasedPermissionsTests(BaseActionsBasedPermissionsTests):
+
+    def _get_test_view(self):
+        return TestViewSet.as_view({
+            'post': 'create',
+        })
+
+    def test_has_create_permissions(self):
+        request = factory.post(
+            '/', {'name': 'foobar'}, format='json',
+            HTTP_AUTHORIZATION=self.permitted_credentials
+        )
+
+        response = self.test_view(request)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_does_not_have_create_permissions(self):
+        request = factory.post(
+            '/', {'name': 'foobar'}, format='json',
+            HTTP_AUTHORIZATION=self.disallowed_credentials
+        )
+
+        response = self.test_view(request)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class ListActionsBasedPermissionsTests(BaseActionsBasedPermissionsTests):
+
+    def _get_test_view(self):
+        return TestViewSet.as_view({
+            'get': 'list',
+        })
+
+    def test_list_does_not_have_default_permissions(self):
+        request = factory.get(
+            '/', format='json',
+            HTTP_AUTHORIZATION=self.disallowed_credentials
+        )
+
+        response = self.test_view(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class RetrieveActionsBasedPermissionsTests(BaseActionsBasedPermissionsTests):
+
+    def _get_test_view(self):
+        return TestViewSet.as_view({
+            'get': 'retrieve',
+        })
+
+    def test_retrieve_does_not_have_default_permissions(self):
+        request = factory.get(
+            '/', format='json',
+            HTTP_AUTHORIZATION=self.disallowed_credentials
+        )
+
+        response = self.test_view(request, pk=self.group.pk)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class UpdateActionsBasedPermissionsTests(BaseActionsBasedPermissionsTests):
+
+    def _get_test_view(self):
+        return TestViewSet.as_view({
+            'put': 'update',
+        })
+
+    def test_has_update_permissions(self):
+        request = factory.put(
+            '/', {'name': 'foobar'}, format='json',
+            HTTP_AUTHORIZATION=self.permitted_credentials
+        )
+
+        response = self.test_view(request, pk=self.group.pk)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_does_not_have_update_permissions(self):
+        request = factory.put(
+            '/', {'name': 'foobar'}, format='json',
+            HTTP_AUTHORIZATION=self.disallowed_credentials
+        )
+
+        response = self.test_view(request, pk=self.group.pk)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class DestroyActionsBasedPermissionsTests(BaseActionsBasedPermissionsTests):
+
+    def _get_test_view(self):
+        return TestViewSet.as_view({
+            'delete': 'destroy'
+        })
+
+    def test_has_destroy_permissions(self):
+        request = factory.delete(
+            '/', {'name': 'foobar'}, format='json',
+            HTTP_AUTHORIZATION=self.permitted_credentials
+        )
+
+        response = self.test_view(request, pk=self.group.pk)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_does_not_have_destroy_permissions(self):
+        request = factory.delete(
+            '/', {'name': 'foobar'}, format='json',
+            HTTP_AUTHORIZATION=self.disallowed_credentials
+        )
+
+        response = self.test_view(request, pk=self.group.pk)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class ActionsBasedPermissionsOnViewSetsOnlyTests(BaseActionsBasedPermissionsTests):
+
+    def _get_test_view(self):
+        class TestView(
+            mixins.CreateModelMixin,
+            mixins.ListModelMixin,
+            mixins.RetrieveModelMixin,
+            mixins.UpdateModelMixin,
+            mixins.DestroyModelMixin,
+            generics.GenericAPIView
+        ):
+            queryset = Group.objects.all()
+            serializer_class = GroupSerializer
+            authentication_classes = [authentication.BasicAuthentication]
+            permission_classes = [ActionsBasedPermissions]
+
+        return TestView.as_view()
+
+    def test_raises_exception_if_not_used_on_viewset(self):
+        request = factory.get(
+            '/', format='json',
+            HTTP_AUTHORIZATION=self.permitted_credentials
+        )
+
+        self.assertRaises(
+            ImproperlyConfigured, self.test_view, request
+        )

--- a/mtp_api/apps/mtp_auth/fixtures/initial_groups.json
+++ b/mtp_api/apps/mtp_auth/fixtures/initial_groups.json
@@ -22,8 +22,9 @@
     "name": "PrisonClerk",
     "permissions": [
       ["view_transaction", "transaction", "transaction"],
-      ["add_transaction", "transaction", "transaction"],
-      ["change_transaction", "transaction", "transaction"]
+      ["take_transaction", "transaction", "transaction"],
+      ["release_transaction", "transaction", "transaction"],
+      ["patch_credited_transaction", "transaction", "transaction"]
     ]
   }
 }

--- a/mtp_api/apps/transaction/migrations/0006_auto_20150807_1554.py
+++ b/mtp_api/apps/transaction/migrations/0006_auto_20150807_1554.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transaction', '0005_auto_20150727_1610'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='transaction',
+            options={'permissions': (('view_transaction', 'Can view transaction'), ('take_transaction', 'Can take transaction'), ('release_transaction', 'Can release transaction'), ('patch_credited_transaction', 'Can patch credited transaction')), 'ordering': ('received_at',)},
+        ),
+    ]

--- a/mtp_api/apps/transaction/models.py
+++ b/mtp_api/apps/transaction/models.py
@@ -68,7 +68,12 @@ class Transaction(TimeStampedModel):
 
     class Meta:
         ordering = ('received_at',)
-        permissions = (("view_transaction", "Can view transaction"),)
+        permissions = (
+            ("view_transaction", "Can view transaction"),
+            ("take_transaction", "Can take transaction"),
+            ("release_transaction", "Can release transaction"),
+            ("patch_credited_transaction", "Can patch credited transaction"),
+        )
 
 
 class Log(TimeStampedModel):

--- a/mtp_api/apps/transaction/permissions.py
+++ b/mtp_api/apps/transaction/permissions.py
@@ -16,14 +16,11 @@ class IsOwnPrison(BasePermission):
 
 
 class TransactionPermissions(ActionsBasedPermissions):
-    actions_perms_map = {
-        'create': ['%(app_label)s.add_%(model_name)s'],
+    actions_perms_map = ActionsBasedPermissions.actions_perms_map.copy()
+    actions_perms_map.update({
         'list': ['%(app_label)s.view_%(model_name)s'],
         'retrieve': ['%(app_label)s.view_%(model_name)s'],
-        'update': ['%(app_label)s.change_%(model_name)s'],
-        'partial_update': ['%(app_label)s.change_%(model_name)s'],
-        'destroy': ['%(app_label)s.delete_%(model_name)s'],
         'take': ['%(app_label)s.take_%(model_name)s'],
         'release': ['%(app_label)s.release_%(model_name)s'],
         'patch_credited': ['%(app_label)s.patch_credited_%(model_name)s']
-    }
+    })

--- a/mtp_api/apps/transaction/permissions.py
+++ b/mtp_api/apps/transaction/permissions.py
@@ -1,11 +1,29 @@
 from rest_framework.permissions import BasePermission
 
+from core.permissions import ActionsBasedPermissions
+
+
 class IsOwner(BasePermission):
 
     def has_permission(self, request, view):
         return str(request.user.id) == view.kwargs.get('user_id')
 
+
 class IsOwnPrison(BasePermission):
 
     def has_permission(self, request, view):
         return request.user.prisonusermapping.prisons.filter(pk=view.kwargs.get('prison_id')).exists()
+
+
+class TransactionPermissions(ActionsBasedPermissions):
+    actions_perms_map = {
+        'create': ['%(app_label)s.add_%(model_name)s'],
+        'list': ['%(app_label)s.view_%(model_name)s'],
+        'retrieve': ['%(app_label)s.view_%(model_name)s'],
+        'update': ['%(app_label)s.change_%(model_name)s'],
+        'partial_update': ['%(app_label)s.change_%(model_name)s'],
+        'destroy': ['%(app_label)s.delete_%(model_name)s'],
+        'take': ['%(app_label)s.take_%(model_name)s'],
+        'release': ['%(app_label)s.release_%(model_name)s'],
+        'patch_credited': ['%(app_label)s.patch_credited_%(model_name)s']
+    }

--- a/mtp_api/apps/transaction/views.py
+++ b/mtp_api/apps/transaction/views.py
@@ -8,7 +8,6 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
-from core.permissions import FullDjangoModelPermissions
 from mtp_auth.models import PrisonUserMapping
 from prison.models import Prison
 
@@ -17,7 +16,7 @@ from .serializers import TransactionSerializer, \
     CreditedOnlyTransactionSerializer
 from .constants import TRANSACTION_STATUS, TAKE_LIMIT, \
     DEFAULT_SLICE_SIZE
-from .permissions import IsOwner, IsOwnPrison
+from .permissions import IsOwner, IsOwnPrison, TransactionPermissions
 
 
 class StatusChoiceFilter(django_filters.ChoiceFilter):
@@ -68,7 +67,7 @@ class TransactionView(
 
     ordering = ('received_at',)
     permission_classes = (
-        IsAuthenticated, IsOwnPrison, FullDjangoModelPermissions
+        IsAuthenticated, IsOwnPrison, TransactionPermissions
     )
 
     def get_queryset(self, filter_by_user=True, filter_by_prison=True):


### PR DESCRIPTION
This creates a new ActionsBasedPermissions to manage permissions on a view.

The old version couldn't distinguish between a POST to create a transaction
and a POST to take a transaction.

The new version checks for individual permissions so that they can be
assigned and managed better.