### PR TITLE
Add Permission Checks to PrisonerLocationView

### DIFF
--- a/mtp_api/apps/core/tests/utils.py
+++ b/mtp_api/apps/core/tests/utils.py
@@ -3,16 +3,21 @@ from oauth2_provider.models import Application
 from django.contrib.auth.models import User
 
 from prison.models import Prison
-from mtp_auth.tests.mommy_recipes import create_prison_user_mapping
+from mtp_auth.tests.mommy_recipes import create_prison_user_mapping, \
+    create_prisoner_location_admins
 
 
 def make_test_users(users_per_prison=1):
-    users = []
+    # prison clerks
+    prison_clerks = []
     for prison in Prison.objects.all():
         for index in range(users_per_prison):
             pu = create_prison_user_mapping(prison)
-            users.append(pu.user)
-    return users
+            prison_clerks.append(pu.user)
+
+    # prisoner location admin
+    prisoner_location_admins = create_prisoner_location_admins()
+    return (prison_clerks, prisoner_location_admins)
 
 
 def make_test_oauth_applications():

--- a/mtp_api/apps/mtp_auth/fixtures/initial_groups.json
+++ b/mtp_api/apps/mtp_auth/fixtures/initial_groups.json
@@ -3,8 +3,10 @@
   "model": "auth.group",
   "pk": 1,
   "fields": {
-    "name": "NOMSFinance",
-    "permissions": []
+    "name": "PrisonerLocationAdmin",
+    "permissions": [
+      ["add_prisonerlocation", "prison", "prisonerlocation"]
+    ]
   }
 },
 {

--- a/mtp_api/apps/mtp_auth/tests/mommy_recipes.py
+++ b/mtp_api/apps/mtp_auth/tests/mommy_recipes.py
@@ -1,5 +1,5 @@
 from model_mommy import timezone
-from model_mommy.mommy import make
+from model_mommy.mommy import make, make_recipe
 from model_mommy.recipe import Recipe, foreign_key
 
 from django.contrib.auth.models import User, Group
@@ -10,16 +10,17 @@ from mtp_auth.models import PrisonUserMapping
 
 
 NOW = lambda: timezone.now()
-prison_user = Recipe(User,
-                     email=None,
-                     is_staff=False,
-                     is_active=True,
-                     is_superuser=False,
-                     last_login=NOW,
-                     created=NOW)
+basic_user = Recipe(
+    User,
+    is_staff=False,
+    is_active=True,
+    is_superuser=False,
+    last_login=NOW
+)
 
-prison_user_mapping = Recipe(PrisonUserMapping,
-                             user=foreign_key(prison_user))
+prison_user_mapping = Recipe(
+    PrisonUserMapping, user=foreign_key(basic_user)
+)
 
 
 def create_prison_user_mapping(prison):
@@ -44,3 +45,17 @@ def create_prison_user_mapping(prison):
     pu.user.save()
     pu.user.groups.add(prison_clerk_group)
     return pu
+
+
+def create_prisoner_location_admins():
+    name_and_password = 'prisoner_location_admin'
+
+    prisoner_location_admin_group = Group.objects.get(name='PrisonerLocationAdmin')
+    plu = basic_user.make(
+        username=name_and_password
+    )
+    plu.set_password(name_and_password)
+    plu.save()
+    plu.groups.add(prisoner_location_admin_group)
+
+    return [plu]

--- a/mtp_api/apps/mtp_auth/tests/test_views.py
+++ b/mtp_api/apps/mtp_auth/tests/test_views.py
@@ -16,7 +16,7 @@ class UserViewTestCase(APITestCase):
 
     def setUp(self):
         super(UserViewTestCase, self).setUp()
-        self.users = make_test_users(users_per_prison=2)
+        self.users, _ = make_test_users(users_per_prison=2)
         self.prisons = Prison.objects.all()
         make_test_oauth_applications()
 

--- a/mtp_api/apps/prison/tests/test_views.py
+++ b/mtp_api/apps/prison/tests/test_views.py
@@ -18,13 +18,25 @@ class PrisonerLocationViewTestCase(APITestCase):
 
     def setUp(self):
         super(PrisonerLocationViewTestCase, self).setUp()
-        self.users = make_test_users()
+        self.prison_clerks, self.users = make_test_users()
         self.prisons = Prison.objects.all()
         make_test_oauth_applications()
 
     @property
     def list_url(self):
         return reverse('prisonerlocation-list')
+
+    def test_fails_without_permissions(self):
+        unauthorised_user = self.prison_clerks[0]
+
+        self.client.force_authenticate(user=unauthorised_user)
+        response = self.client.post(
+            self.list_url, data={}, format='json'
+        )
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_403_FORBIDDEN
+        )
 
     def test_cannot_create_if_not_logged_in(self):
         response = self.client.post(

--- a/mtp_api/apps/prison/views.py
+++ b/mtp_api/apps/prison/views.py
@@ -2,6 +2,8 @@ from rest_framework import mixins, viewsets, status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from core.permissions import ActionsBasedPermissions
+
 from .models import PrisonerLocation
 from .serializers import PrisonerLocationSerializer
 
@@ -11,7 +13,9 @@ class PrisonerLocationView(
 ):
     queryset = PrisonerLocation.objects.all()
 
-    permission_classes = (IsAuthenticated, )
+    permission_classes = (
+        IsAuthenticated, ActionsBasedPermissions
+    )
     serializer_class = PrisonerLocationSerializer
 
     def create(self, request, *args, **kwargs):

--- a/mtp_api/apps/transaction/tests/test_views.py
+++ b/mtp_api/apps/transaction/tests/test_views.py
@@ -40,7 +40,7 @@ class BaseTransactionViewTestCase(APITestCase):
 
     def setUp(self):
         super(BaseTransactionViewTestCase, self).setUp()
-        self.owners = make_test_users(users_per_prison=2)
+        self.owners, _ = make_test_users(users_per_prison=2)
         self.transactions = generate_transactions(
             uploads=2, transaction_batch=50
         )

--- a/mtp_api/apps/transaction/tests/utils.py
+++ b/mtp_api/apps/transaction/tests/utils.py
@@ -115,4 +115,3 @@ def generate_transactions(uploads=2, transaction_batch=30):
             trans = Transaction.objects.create(**data)
             transactions.append(trans)
     return transactions
-


### PR DESCRIPTION
This makes sure that only users beloging to the PrisonerLocationAdmin group can access the PrisonerLocation API.