### PR TITLE
Prisoner hash

### DIFF
--- a/mtp_api/apps/core/management/commands/load_test_data.py
+++ b/mtp_api/apps/core/management/commands/load_test_data.py
@@ -1,9 +1,12 @@
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 
 from core.tests.utils import make_test_users, \
     make_test_oauth_applications
+
+
+User = get_user_model()
 
 
 class Command(BaseCommand):

--- a/mtp_api/apps/core/tests/test_permissions.py
+++ b/mtp_api/apps/core/tests/test_permissions.py
@@ -1,7 +1,8 @@
 import base64
 
 from django.test import TestCase
-from django.contrib.auth.models import Group, Permission, User
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group, Permission
 from django.core.exceptions import ImproperlyConfigured
 
 from rest_framework import (
@@ -12,6 +13,8 @@ from rest_framework.test import APIRequestFactory
 
 from core.permissions import ActionsBasedPermissions
 
+
+User = get_user_model()
 
 factory = APIRequestFactory()
 

--- a/mtp_api/apps/core/tests/utils.py
+++ b/mtp_api/apps/core/tests/utils.py
@@ -1,10 +1,13 @@
 from oauth2_provider.models import Application
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 
 from prison.models import Prison
 from mtp_auth.tests.mommy_recipes import create_prison_user_mapping, \
     create_prisoner_location_admins
+
+
+User = get_user_model()
 
 
 def make_test_users(users_per_prison=1):

--- a/mtp_api/apps/mtp_auth/serializers.py
+++ b/mtp_api/apps/mtp_auth/serializers.py
@@ -1,6 +1,8 @@
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 
 from rest_framework import serializers
+
+User = get_user_model()
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/mtp_api/apps/mtp_auth/tests/mommy_recipes.py
+++ b/mtp_api/apps/mtp_auth/tests/mommy_recipes.py
@@ -2,12 +2,14 @@ from model_mommy import timezone
 from model_mommy.mommy import make, make_recipe
 from model_mommy.recipe import Recipe, foreign_key
 
-from django.contrib.auth.models import User, Group
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from django.utils.text import slugify
 from django.utils.crypto import get_random_string
 
 from mtp_auth.models import PrisonUserMapping
 
+User = get_user_model()
 
 NOW = lambda: timezone.now()
 basic_user = Recipe(

--- a/mtp_api/apps/mtp_auth/views.py
+++ b/mtp_api/apps/mtp_auth/views.py
@@ -1,10 +1,12 @@
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.http import Http404
 
 from rest_framework.permissions import IsAuthenticated
 from rest_framework import viewsets, mixins
 
 from .serializers import UserSerializer
+
+User = get_user_model()
 
 
 class UserViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):

--- a/mtp_api/apps/prison/migrations/0004_prisonerlocation_prisoner_hash.py
+++ b/mtp_api/apps/prison/migrations/0004_prisonerlocation_prisoner_hash.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('prison', '0003_remove_prisonerlocation_upload_counter'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='prisonerlocation',
+            name='prisoner_hash',
+            field=models.CharField(blank=True, max_length=250),
+        ),
+    ]

--- a/mtp_api/apps/prison/migrations/0005_populate_prisoner_hash.py
+++ b/mtp_api/apps/prison/migrations/0005_populate_prisoner_hash.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import hashlib
+
+from django.db import models, migrations
+
+
+def calculate_prisoner_hash(location):
+    original = '{number}_{dob}'.format(
+        number=location.prisoner_number.lower(),
+        dob=location.prisoner_dob.strftime('%d/%m/%Y')
+    )
+    hash_object = hashlib.sha256(original.encode())
+    return hash_object.hexdigest()
+
+
+def populate_prisoner_hash(apps, schema_editor):
+    PrisonerLocation = apps.get_model("prison", "PrisonerLocation")
+
+    for location in PrisonerLocation.objects.all():
+        location.prisoner_hash = calculate_prisoner_hash(location)
+        location.save(update_fields=['prisoner_hash'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('prison', '0004_prisonerlocation_prisoner_hash'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_prisoner_hash),
+    ]

--- a/mtp_api/apps/prison/migrations/0006_auto_20150811_1321.py
+++ b/mtp_api/apps/prison/migrations/0006_auto_20150811_1321.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('prison', '0005_populate_prisoner_hash'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='prisonerlocation',
+            name='prisoner_hash',
+            field=models.CharField(max_length=250),
+        ),
+    ]

--- a/mtp_api/apps/prison/tests/test_models.py
+++ b/mtp_api/apps/prison/tests/test_models.py
@@ -1,0 +1,68 @@
+from model_mommy import mommy
+
+from django.test import TestCase
+
+from prison.models import Prison, PrisonerLocation
+
+from .utils import random_prisoner_number, random_prisoner_dob
+
+
+class PrisonerHashTestCase(TestCase):
+    fixtures = [
+        'test_prisons.json'
+    ]
+
+    def setUp(self):
+        super(PrisonerHashTestCase, self).setUp()
+        self.user = mommy.make_recipe('mtp_auth.tests.basic_user')
+
+        self.pl = PrisonerLocation(
+            created_by=self.user,
+            prisoner_number=random_prisoner_number(),
+            prisoner_dob=random_prisoner_dob(),
+            prison=Prison.objects.order_by('?').first()
+        )
+
+    def test_save_new(self):
+        self.assertEqual(self.pl.prisoner_hash, '')
+        self.pl.save()
+        self.assertNotEqual(self.pl.prisoner_hash, '')
+
+    def test_save_existing(self):
+        """
+        Tests that changing the prison of an existing prisoner
+        location won't change the prisoner_hash.
+        """
+        self.pl.save()
+
+        prisoner_hash = self.pl.prisoner_hash
+
+        self.pl.prison = Prison.objects.order_by('?').first()
+        self.pl.save()
+        self.assertEqual(self.pl.prisoner_hash, prisoner_hash)
+
+    def test_save_after_updating_prisoner_number(self):
+        """
+        Tests that changing the prison_number of an existing prisoner
+        location changes the prisoner_hash.
+        """
+        self.pl.save()
+
+        prisoner_hash = self.pl.prisoner_hash
+
+        self.pl.prisoner_number = random_prisoner_number()
+        self.pl.save()
+        self.assertNotEqual(self.pl.prisoner_hash, prisoner_hash)
+
+    def test_save_after_updating_prisoner_dob(self):
+        """
+        Tests that changing the prison_dob of an existing prisoner
+        location changes the prisoner_hash.
+        """
+        self.pl.save()
+
+        prisoner_hash = self.pl.prisoner_hash
+
+        self.pl.prisoner_dob = random_prisoner_dob()
+        self.pl.save()
+        self.assertNotEqual(self.pl.prisoner_hash, prisoner_hash)


### PR DESCRIPTION
This adds a new field `prisoner_hash` to `PrisonerLocation` so that we can join tables easily using this value instead of `(prisoner_id, prisoner_dob)`.

I've also cleaned up the imports making sure we always use `get_user_model` instead of the `auth.User` one.