### PR TITLE
Per application permissions

### DIFF
--- a/mtp_api/apps/core/tests/utils.py
+++ b/mtp_api/apps/core/tests/utils.py
@@ -5,6 +5,8 @@ from django.contrib.auth.models import User
 from prison.models import Prison
 from mtp_auth.tests.mommy_recipes import create_prison_user_mapping, \
     create_prisoner_location_admins, create_bank_admins
+from mtp_auth.constants import CASHBOOK_OAUTH_CLIENT_ID, \
+    BANK_ADMIN_OAUTH_CLIENT_ID, PRISONER_LOCATION_OAUTH_CLIENT_ID
 
 
 def make_test_users(clerks_per_prison=1):
@@ -24,20 +26,22 @@ def make_test_users(clerks_per_prison=1):
 
 
 def make_test_oauth_applications():
-    Application.objects.get_or_create(
-        client_id='cashbook',
-        client_type='confidential',
-        authorization_grant_type='password',
-        client_secret='cashbook',
-        name='cashbook',
-        user=User.objects.first()
-    )
+    """
+    Creates test oauth clients with secret == client id
+    for test purposes.
+    """
+    user = User.objects.first()
 
-    Application.objects.get_or_create(
-        client_id='prisoner-location-admin',
-        client_type='confidential',
-        authorization_grant_type='password',
-        client_secret='prisoner-location-admin',
-        name='prisoner-location-admin',
-        user=User.objects.first()
-    )
+    for client_id in [
+        CASHBOOK_OAUTH_CLIENT_ID,
+        BANK_ADMIN_OAUTH_CLIENT_ID,
+        PRISONER_LOCATION_OAUTH_CLIENT_ID
+    ]:
+        Application.objects.get_or_create(
+            client_id=client_id,
+            client_type='confidential',
+            authorization_grant_type='password',
+            client_secret=client_id,
+            name=client_id,
+            user=user
+        )

--- a/mtp_api/apps/mtp_auth/constants.py
+++ b/mtp_api/apps/mtp_auth/constants.py
@@ -1,0 +1,3 @@
+CASHBOOK_OAUTH_CLIENT_ID = 'cashbook'
+BANK_ADMIN_OAUTH_CLIENT_ID = 'bank-admin'
+PRISONER_LOCATION_OAUTH_CLIENT_ID = 'prisoner-locations'

--- a/mtp_api/apps/mtp_auth/permissions.py
+++ b/mtp_api/apps/mtp_auth/permissions.py
@@ -1,0 +1,29 @@
+from rest_framework.permissions import BasePermission
+
+from .constants import CASHBOOK_OAUTH_CLIENT_ID, \
+    BANK_ADMIN_OAUTH_CLIENT_ID, PRISONER_LOCATION_OAUTH_CLIENT_ID
+
+
+class ClientIDPermissions(BasePermission):
+    """
+    Permissions class which checks that an API view can only be accessed
+    by a specific oauth application.
+    """
+    client_id = None
+
+    def has_permission(self, request, view):
+        if not request.auth or not request.auth.application:
+            return False
+        return self.client_id == request.auth.application.client_id
+
+
+class CashbookClientIDPermissions(ClientIDPermissions):
+    client_id = CASHBOOK_OAUTH_CLIENT_ID
+
+
+class BankAdminClientIDPermissions(ClientIDPermissions):
+    client_id = BANK_ADMIN_OAUTH_CLIENT_ID
+
+
+class PrisonerLocationClientIDPermissions(ClientIDPermissions):
+    client_id = PRISONER_LOCATION_OAUTH_CLIENT_ID

--- a/mtp_api/apps/mtp_auth/tests/test_permissions.py
+++ b/mtp_api/apps/mtp_auth/tests/test_permissions.py
@@ -1,0 +1,43 @@
+import mock
+from django.test import TestCase
+
+from mtp_auth.permissions import ClientIDPermissions
+
+
+class TestClientIDPermissions(ClientIDPermissions):
+    client_id = 'test'
+
+
+class ClientIDPermissionsTestCase(TestCase):
+
+    def setUp(self):
+        super(ClientIDPermissionsTestCase, self).setUp()
+        self.permissions = TestClientIDPermissions()
+        self.request = mock.MagicMock()
+        self.view = mock.MagicMock()
+
+    def test_no_permissions_without_auth(self):
+        self.request.auth = None
+        self.assertFalse(
+            self.permissions.has_permission(self.request, self.view)
+        )
+
+    def test_no_permissions_without_oauth_application(self):
+        self.request.auth.application = None
+        self.assertFalse(
+            self.permissions.has_permission(self.request, self.view)
+        )
+
+    def test_no_permissions_with_mismatching_clients(self):
+        self.request.auth.application.client_id = 'different-client-id'
+
+        self.assertFalse(
+            self.permissions.has_permission(self.request, self.view)
+        )
+
+    def test_has_permissions(self):
+        self.request.auth.application.client_id = TestClientIDPermissions.client_id
+
+        self.assertTrue(
+            self.permissions.has_permission(self.request, self.view)
+        )

--- a/mtp_api/apps/mtp_auth/tests/utils.py
+++ b/mtp_api/apps/mtp_auth/tests/utils.py
@@ -14,11 +14,12 @@ class AuthTestCaseMixin(object):
         'PrisonClerk': CASHBOOK_OAUTH_CLIENT_ID
     }
 
-    def _get_http_authorization_token_for_user(self, user):
-        group = user.groups.first()
-        if not group:
-            return None
-        client_id = self.APPLICATION_ID_MAP.get(group.name)
+    def _get_http_authorization_token_for_user(self, user, client_id=None):
+        if not client_id:
+            group = user.groups.first()
+            if not group:
+                return None
+            client_id = self.APPLICATION_ID_MAP.get(group.name)
         application = Application.objects.get(client_id=client_id)
 
         token = get_random_string()
@@ -30,6 +31,8 @@ class AuthTestCaseMixin(object):
         )
         return token
 
-    def get_http_authorization_for_user(self, user):
-        token = self._get_http_authorization_token_for_user(user)
+    def get_http_authorization_for_user(self, user, client_id=None):
+        token = self._get_http_authorization_token_for_user(
+            user, client_id=client_id
+        )
         return "Bearer {0}".format(token)

--- a/mtp_api/apps/mtp_auth/tests/utils.py
+++ b/mtp_api/apps/mtp_auth/tests/utils.py
@@ -1,0 +1,35 @@
+import datetime
+from django.utils import timezone
+from django.utils.crypto import get_random_string
+
+from oauth2_provider.models import Application, AccessToken
+from mtp_auth.constants import CASHBOOK_OAUTH_CLIENT_ID, \
+    BANK_ADMIN_OAUTH_CLIENT_ID, PRISONER_LOCATION_OAUTH_CLIENT_ID
+
+
+class AuthTestCaseMixin(object):
+    APPLICATION_ID_MAP = {
+        'PrisonerLocationAdmin': PRISONER_LOCATION_OAUTH_CLIENT_ID,
+        'BankAdmin': BANK_ADMIN_OAUTH_CLIENT_ID,
+        'PrisonClerk': CASHBOOK_OAUTH_CLIENT_ID
+    }
+
+    def _get_http_authorization_token_for_user(self, user):
+        group = user.groups.first()
+        if not group:
+            return None
+        client_id = self.APPLICATION_ID_MAP.get(group.name)
+        application = Application.objects.get(client_id=client_id)
+
+        token = get_random_string()
+        AccessToken.objects.create(
+            token=token,
+            application=application,
+            user=user,
+            expires=timezone.now() + datetime.timedelta(days=30)
+        )
+        return token
+
+    def get_http_authorization_for_user(self, user):
+        token = self._get_http_authorization_token_for_user(user)
+        return "Bearer {0}".format(token)

--- a/mtp_api/apps/prison/views.py
+++ b/mtp_api/apps/prison/views.py
@@ -3,6 +3,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from core.permissions import ActionsBasedPermissions
+from mtp_auth.permissions import PrisonerLocationClientIDPermissions
 
 from .models import PrisonerLocation
 from .serializers import PrisonerLocationSerializer
@@ -14,7 +15,8 @@ class PrisonerLocationView(
     queryset = PrisonerLocation.objects.all()
 
     permission_classes = (
-        IsAuthenticated, ActionsBasedPermissions
+        IsAuthenticated, PrisonerLocationClientIDPermissions,
+        ActionsBasedPermissions
     )
     serializer_class = PrisonerLocationSerializer
 

--- a/mtp_api/apps/transaction/permissions.py
+++ b/mtp_api/apps/transaction/permissions.py
@@ -1,5 +1,7 @@
 from rest_framework.permissions import BasePermission
 
+from mtp_auth.models import PrisonUserMapping
+
 from core.permissions import ActionsBasedPermissions
 
 
@@ -12,7 +14,12 @@ class IsOwner(BasePermission):
 class IsOwnPrison(BasePermission):
 
     def has_permission(self, request, view):
-        return request.user.prisonusermapping.prisons.filter(pk=view.kwargs.get('prison_id')).exists()
+        try:
+            prison_user_mapping = request.user.prisonusermapping
+        except PrisonUserMapping.DoesNotExist:
+            return False
+
+        return prison_user_mapping.prisons.filter(pk=view.kwargs.get('prison_id')).exists()
 
 
 class TransactionPermissions(ActionsBasedPermissions):

--- a/mtp_api/apps/transaction/tests/test_views.py
+++ b/mtp_api/apps/transaction/tests/test_views.py
@@ -9,6 +9,7 @@ from rest_framework.test import APITestCase
 
 from core.tests.utils import make_test_users, make_test_oauth_applications
 from mtp_auth.models import PrisonUserMapping
+from mtp_auth.tests.utils import AuthTestCaseMixin
 
 from prison.models import Prison
 
@@ -27,7 +28,7 @@ def get_prisons_for_user(user):
     return PrisonUserMapping.objects.get(user=user).prisons.all()
 
 
-class BaseTransactionViewTestCase(APITestCase):
+class BaseTransactionViewTestCase(AuthTestCaseMixin, APITestCase):
     fixtures = [
         'initial_groups.json',
         'test_prisons.json'
@@ -84,9 +85,7 @@ class TransactionRejectsRequestsWithoutPermissionTestMixin(object):
     ENDPOINT_VERB = 'get'
 
     def get_user_and_prison(self):
-        prison = self.prisons[0]
-        user = get_users_for_prison(prison)[0]
-        return user, prison
+        return self.bank_admins[0], self.prisons[0]
 
     def test_fails_without_permissions(self):
         """
@@ -95,15 +94,13 @@ class TransactionRejectsRequestsWithoutPermissionTestMixin(object):
         """
         user, prison = self.get_user_and_prison()
 
-        # delete user from groups
-        user.groups.all().delete()
-
         url = self._get_url(user, prison)
 
-        self.client.force_authenticate(user=user)
-
         verb_callable = getattr(self.client, self.ENDPOINT_VERB)
-        response = verb_callable(url, format='json')
+        response = verb_callable(
+            url, format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(user)
+        )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -119,10 +116,14 @@ class TransactionListEndpointTestCase(BaseTransactionViewTestCase):
         # authenticate, just in case
         prison = [t.prison for t in self.transactions if t.prison][0]
         user = get_users_for_prison(prison)[0]
-        self.client.force_authenticate(user=user)
 
-        response = self.client.get(url, format='json')
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        response = self.client.get(
+            url, format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(user)
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_403_FORBIDDEN
+        )
 
 
 class TransactionListByPrisonEndpointTestCase(
@@ -139,10 +140,12 @@ class TransactionListByPrisonEndpointTestCase(
 
             expected_owners = get_users_for_prison(prison)
             user = expected_owners[0]
-            self.client.force_authenticate(user=user)
 
             url = self._get_url(user, prison, status=status_param)
-            response = self.client.get(url, format='json')
+            response = self.client.get(
+                url, format='json',
+                HTTP_AUTHORIZATION=self.get_http_authorization_for_user(user)
+            )
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(response.data['count'], len(expected_ids))
@@ -181,9 +184,10 @@ class TransactionListByPrisonEndpointTestCase(
 
         url = self._get_url(logged_in_user, other_prison)
 
-        self.client.force_authenticate(user=logged_in_user)
-
-        response = self.client.get(url, format='json')
+        response = self.client.get(
+            url, format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(logged_in_user)
+        )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -216,8 +220,6 @@ class TransactionListByPrisonAndUserEndpointTestCase(
 
     def _request_and_assert(self, status_param=None):
         for owner in self.prison_clerks:
-            self.client.force_authenticate(user=owner)
-
             prisons = get_prisons_for_user(owner)
 
             for prison in prisons:
@@ -229,7 +231,10 @@ class TransactionListByPrisonAndUserEndpointTestCase(
                 ]
                 url = self._get_url(owner, prison, status=status_param)
 
-                response = self.client.get(url, format='json')
+                response = self.client.get(
+                    url, format='json',
+                    HTTP_AUTHORIZATION=self.get_http_authorization_for_user(owner)
+                )
 
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
                 self.assertEqual(response.data['count'], len(expected_ids))
@@ -270,9 +275,10 @@ class TransactionListByPrisonAndUserEndpointTestCase(
 
         url = self._get_url(other_user, other_prison)
 
-        self.client.force_authenticate(user=logged_in_user)
-
-        response = self.client.get(url, format='json')
+        response = self.client.get(
+            url, format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(logged_in_user)
+        )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -333,10 +339,11 @@ class TransactionsTakeTestCase(
         )
 
         # request
-        self.client.force_authenticate(user=owner)
-
         url = self._get_url(owner, prison, count)
-        response = self.client.post(url, format='json')
+        response = self.client.post(
+            url, format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(owner)
+        )
 
         self.assertEqual(response.status_code, status.HTTP_303_SEE_OTHER)
         self.assertEqual(
@@ -387,10 +394,11 @@ class TransactionsTakeTestCase(
         )
 
         # request
-        self.client.force_authenticate(user=logged_in_user)
-
         url = self._get_url(transactions_owner, prison, 1)
-        response = self.client.post(url, format='json')
+        response = self.client.post(
+            url, format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(logged_in_user)
+        )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -420,12 +428,16 @@ class TransactionsTakeTestCase(
             self._get_pending_transactions_qs(prison, user).count(), 0
         )
 
+        http_authorization_header = self.get_http_authorization_for_user(user)
+
         # request TAKE_LIMIT-1
         count = TAKE_LIMIT-1
-        self.client.force_authenticate(user=user)
 
         url = self._get_url(user, prison, count)
-        response = self.client.post(url, format='json')
+        response = self.client.post(
+            url, format='json',
+            HTTP_AUTHORIZATION=http_authorization_header
+        )
 
         self.assertEqual(response.status_code, status.HTTP_303_SEE_OTHER)
 
@@ -436,7 +448,10 @@ class TransactionsTakeTestCase(
 
         # request 2 more => should fail
         url = self._get_url(user, prison, 2)
-        response = self.client.post(url, format='json')
+        response = self.client.post(
+            url, format='json',
+            HTTP_AUTHORIZATION=http_authorization_header
+        )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -479,12 +494,13 @@ class TransactionsReleaseTestCase(
         self.assertTrue(len(pending_transactions) > 0)
 
         # request
-        self.client.force_authenticate(user=logged_in_user)
-
         url = self._get_url(transactions_owner, prison2)
-        response = self.client.post(url, {
-            'transaction_ids': [t.id for t in pending_transactions]
-        }, format='json')
+        response = self.client.post(
+            url,
+            {'transaction_ids': [t.id for t in pending_transactions]},
+            format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(logged_in_user)
+        )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -517,12 +533,13 @@ class TransactionsReleaseTestCase(
         currently_available = self._get_available_transactions_qs(prison).count()
 
         # request
-        self.client.force_authenticate(user=logged_in_user)
-
         url = self._get_url(transactions_owner, prison)
-        response = self.client.post(url, {
-            'transaction_ids': [t.id for t in transactions_to_release]
-        }, format='json')
+        response = self.client.post(
+            url,
+            {'transaction_ids': [t.id for t in transactions_to_release]},
+            format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(logged_in_user)
+        )
 
         self.assertEqual(response.status_code, status.HTTP_303_SEE_OTHER)
         self.assertEqual(
@@ -586,12 +603,13 @@ class TransactionsReleaseTestCase(
 
         transactions_to_release = pending_transactions_owner + pending_transactions_logged_in[:1]
 
-        self.client.force_authenticate(user=logged_in_user)
-
         url = self._get_url(transactions_owner, prison)
-        response = self.client.post(url, {
-            'transaction_ids': [t.id for t in transactions_to_release]
-        }, format='json')
+        response = self.client.post(
+            url,
+            {'transaction_ids': [t.id for t in transactions_to_release]},
+            format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(logged_in_user)
+        )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -634,12 +652,13 @@ class TransactionsReleaseTestCase(
 
         transactions_to_release = pending_transactions + credited_transactions[:1]
 
-        self.client.force_authenticate(user=logged_in_user)
-
         url = self._get_url(transactions_owner, prison)
-        response = self.client.post(url, {
-            'transaction_ids': [t.id for t in transactions_to_release]
-        }, format='json')
+        response = self.client.post(
+            url,
+            {'transaction_ids': [t.id for t in transactions_to_release]},
+            format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(logged_in_user)
+        )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -688,12 +707,13 @@ class TransactionsPatchTestCase(
         self.assertTrue(len(pending_transactions) > 0)
 
         # request
-        self.client.force_authenticate(user=logged_in_user)
-
         url = self._get_url(transactions_owner, prison)
-        response = self.client.patch(url, {
-            'transaction_ids': [t.id for t in pending_transactions]
-        }, format='json')
+        response = self.client.patch(
+            url,
+            {'transaction_ids': [t.id for t in pending_transactions]},
+            format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(logged_in_user)
+        )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -720,12 +740,13 @@ class TransactionsPatchTestCase(
         transactions_to_credit = pending_transactions + available_transactions[:1]
 
         # request
-        self.client.force_authenticate(user=user)
-
         url = self._get_url(user, prison)
-        response = self.client.patch(url, {
-            'transaction_ids': [t.id for t in transactions_to_credit]
-        }, format='json')
+        response = self.client.patch(
+            url,
+            {'transaction_ids': [t.id for t in transactions_to_credit]},
+            format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(user)
+        )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -765,8 +786,6 @@ class TransactionsPatchTestCase(
         transactions_to_credit = pending_transactions[:to_credit]
 
         # request
-        self.client.force_authenticate(user=user)
-
         url = self._get_url(user, prison)
         data = [
             {
@@ -774,7 +793,10 @@ class TransactionsPatchTestCase(
                 'credited': True
             } for t in transactions_to_credit
         ]
-        response = self.client.patch(url, data=data, format='json')
+        response = self.client.patch(
+            url, data=data, format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(user)
+        )
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
@@ -827,8 +849,6 @@ class TransactionsPatchTestCase(
         transactions_to_credit = pending_transactions[:to_credit]
 
         # request
-        self.client.force_authenticate(user=user)
-
         url = self._get_url(user, prison)
 
         # invalid data format
@@ -868,7 +888,10 @@ class TransactionsPatchTestCase(
             }
         ]
         for data in invalid_data_list:
-            response = self.client.patch(url, data=data['data'], format='json')
+            response = self.client.patch(
+                url, data=data['data'], format='json',
+                HTTP_AUTHORIZATION=self.get_http_authorization_for_user(user)
+            )
             self.assertEqual(
                 response.status_code,
                 status.HTTP_400_BAD_REQUEST,
@@ -915,9 +938,11 @@ class AdminCreateTransactionsTestCase(
         data_list = self._get_transactions_data()
 
         user = self.bank_admins[0]
-        self.client.force_authenticate(user=user)
 
-        response = self.client.post(url, data=data_list, format='json')
+        response = self.client.post(
+            url, data=data_list, format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(user)
+        )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # check changes in db
@@ -938,4 +963,4 @@ class AdminCreateTransactionsTestCase(
         )
 
     def get_user_and_prison(self):
-        return self.bank_admins[0], None
+        return self.prison_clerks[0], None

--- a/mtp_api/apps/transaction/views.py
+++ b/mtp_api/apps/transaction/views.py
@@ -9,6 +9,8 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
 from mtp_auth.models import PrisonUserMapping
+from mtp_auth.permissions import CashbookClientIDPermissions, \
+    BankAdminClientIDPermissions
 from prison.models import Prison
 
 from .models import Transaction
@@ -68,7 +70,8 @@ class TransactionView(
 
     ordering = ('received_at',)
     permission_classes = (
-        IsAuthenticated, IsOwnPrison, TransactionPermissions
+        IsAuthenticated, CashbookClientIDPermissions,
+        IsOwnPrison, TransactionPermissions
     )
 
     def get_queryset(self, filter_by_user=True, filter_by_prison=True):
@@ -167,7 +170,8 @@ class AdminTransactionView(
     queryset = Transaction.objects.all()
 
     permission_classes = (
-        IsAuthenticated, ActionsBasedPermissions
+        IsAuthenticated, BankAdminClientIDPermissions,
+        ActionsBasedPermissions
     )
     create_serializer_class = CreateTransactionSerializer
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,3 +3,4 @@
 django-extensions==1.5.0
 Werkzeug==0.10.4
 model-mommy==1.2.4
+mock==1.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,3 +4,4 @@ django-extensions==1.5.0
 Werkzeug==0.10.4
 model-mommy==1.2.4
 mock==1.3.0
+six==1.9.0


### PR DESCRIPTION
This adds per-application permissions to the transaction and prisoner locations views so that they can't be accessed by users who logged in using a different oauth application.

- Oauth application ids are now constants so that we can reference them during our tests and when live without hardcoding them every time.
- Replaced the `force_authenticate` call with a token-based one during tests so that we can reliably test the authentication/permissions bit