### PR TITLE
Namespace cashbook transactions

### DIFF
--- a/mtp_api/apps/transaction/permissions.py
+++ b/mtp_api/apps/transaction/permissions.py
@@ -22,7 +22,7 @@ class IsOwnPrison(BasePermission):
         return prison_user_mapping.prisons.filter(pk=view.kwargs.get('prison_id')).exists()
 
 
-class TransactionPermissions(ActionsBasedPermissions):
+class CashbookTransactionPermissions(ActionsBasedPermissions):
     actions_perms_map = ActionsBasedPermissions.actions_perms_map.copy()
     actions_perms_map.update({
         'list': ['%(app_label)s.view_%(model_name)s'],

--- a/mtp_api/apps/transaction/routers.py
+++ b/mtp_api/apps/transaction/routers.py
@@ -1,15 +1,10 @@
 from rest_framework.routers import DefaultRouter, Route
-from transaction.views import TransactionView
 
 
-class TransactionRouter(DefaultRouter):
-
-    def __init__(self):
-        super(TransactionRouter, self).__init__()
-        self.register(r'transactions', TransactionView)
+class CashbookTransactionRouter(DefaultRouter):
 
     def get_routes(self, viewset):
-        simple_routes = super(TransactionRouter, self).get_routes(viewset)
+        simple_routes = super(CashbookTransactionRouter, self).get_routes(viewset)
         extra_routes = [
             Route(
                 url=r'^{prefix}/(?P<prison_id>\w+){trailing_slash}$',

--- a/mtp_api/apps/transaction/serializers.py
+++ b/mtp_api/apps/transaction/serializers.py
@@ -7,7 +7,7 @@ from .signals import transaction_created
 from .models import Transaction
 
 
-class CreditedOnlyTransactionSerializer(serializers.ModelSerializer):
+class CashbookCreditedOnlyTransactionSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(required=True)
     credited = serializers.BooleanField(required=True)
 
@@ -19,7 +19,7 @@ class CreditedOnlyTransactionSerializer(serializers.ModelSerializer):
         )
 
 
-class DefaultTransactionSerializer(serializers.ModelSerializer):
+class CashbookTransactionSerializer(serializers.ModelSerializer):
     sender = serializers.CharField(source='sender_name')
 
     class Meta:
@@ -37,7 +37,7 @@ class DefaultTransactionSerializer(serializers.ModelSerializer):
         )
 
 
-class CreateTransactionListSerializer(serializers.ListSerializer):
+class BankAdminCreateTransactionListSerializer(serializers.ListSerializer):
 
     @transaction.atomic
     def create(self, validated_data):
@@ -64,11 +64,11 @@ class CreateTransactionListSerializer(serializers.ListSerializer):
         return transactions
 
 
-class CreateTransactionSerializer(serializers.ModelSerializer):
+class BankAdminCreateTransactionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Transaction
-        list_serializer_class = CreateTransactionListSerializer
+        list_serializer_class = BankAdminCreateTransactionListSerializer
         fields = (
             'prisoner_number',
             'prisoner_dob',

--- a/mtp_api/apps/transaction/tests/test_views.py
+++ b/mtp_api/apps/transaction/tests/test_views.py
@@ -17,7 +17,7 @@ from prison.models import Prison
 
 from transaction.models import Transaction, Log
 from transaction.constants import TRANSACTION_STATUS, TAKE_LIMIT, LOG_ACTIONS
-from transaction.views import AdminTransactionView
+from transaction.views import BankAdminTransactionView
 
 from .utils import generate_transactions_data, generate_transactions
 
@@ -168,13 +168,13 @@ class CashbookTransactionRejectsRequestsWithoutPermissionTestMixin(
         return self.prison_clerks[0]
 
 
-class TransactionListEndpointTestCase(BaseTransactionViewTestCase):
+class CashbookTransactionListEndpointTestCase(BaseTransactionViewTestCase):
 
     def test_cant_access(self):
         """
         GET on transactions endpoint should 403.
         """
-        url = reverse('transaction-list')
+        url = reverse('cashbook:transaction-list')
 
         # authenticate, just in case
         prison = [t.prison for t in self.transactions if t.prison][0]
@@ -189,7 +189,7 @@ class TransactionListEndpointTestCase(BaseTransactionViewTestCase):
         )
 
 
-class TransactionListByPrisonEndpointTestCase(
+class CashbookTransactionListByPrisonEndpointTestCase(
     CashbookTransactionRejectsRequestsWithoutPermissionTestMixin,
     BaseTransactionViewTestCase
 ):
@@ -221,7 +221,7 @@ class TransactionListByPrisonEndpointTestCase(
 
     def _get_url(self, user, prison, status=None):
         url = reverse(
-            'transaction-prison-list', kwargs={
+            'cashbook:transaction-prison-list', kwargs={
                 'prison_id': prison.pk
             }
         )
@@ -278,7 +278,7 @@ class TransactionListByPrisonEndpointTestCase(
         )
 
 
-class TransactionListByPrisonAndUserEndpointTestCase(
+class CashbookTransactionListByPrisonAndUserEndpointTestCase(
     CashbookTransactionRejectsRequestsWithoutPermissionTestMixin,
     BaseTransactionViewTestCase
 ):
@@ -311,7 +311,7 @@ class TransactionListByPrisonAndUserEndpointTestCase(
 
     def _get_url(self, user, prison, status=None):
         url = reverse(
-            'transaction-prison-user-list', kwargs={
+            'cashbook:transaction-prison-user-list', kwargs={
                 'user_id': user.pk,
                 'prison_id': prison.pk
             }
@@ -366,7 +366,7 @@ class TransactionListByPrisonAndUserEndpointTestCase(
         )
 
 
-class TransactionsTakeTestCase(
+class CashbookTransactionsTakeTestCase(
     CashbookTransactionRejectsRequestsWithoutPermissionTestMixin,
     BaseTransactionViewTestCase
 ):
@@ -374,7 +374,7 @@ class TransactionsTakeTestCase(
 
     def _get_url(self, user, prison, count=None):
         url = reverse(
-            'transaction-prison-user-take', kwargs={
+            'cashbook:transaction-prison-user-take', kwargs={
                 'user_id': user.pk,
                 'prison_id': prison.pk
             }
@@ -415,7 +415,7 @@ class TransactionsTakeTestCase(
         self.assertEqual(
             urlsplit(response['Location']).path,
             reverse(
-                'transaction-prison-user-list', kwargs={
+                'cashbook:transaction-prison-user-list', kwargs={
                     'user_id': owner.pk,
                     'prison_id': prison.pk
                 }
@@ -527,7 +527,7 @@ class TransactionsTakeTestCase(
         )
 
 
-class TransactionsReleaseTestCase(
+class CashbookTransactionsReleaseTestCase(
     CashbookTransactionRejectsRequestsWithoutPermissionTestMixin,
     BaseTransactionViewTestCase
 ):
@@ -535,7 +535,7 @@ class TransactionsReleaseTestCase(
 
     def _get_url(self, user, prison):
         return reverse(
-            'transaction-prison-user-release', kwargs={
+            'cashbook:transaction-prison-user-release', kwargs={
                 'user_id': user.pk,
                 'prison_id': prison.pk
             }
@@ -612,7 +612,7 @@ class TransactionsReleaseTestCase(
         self.assertEqual(
             urlsplit(response['Location']).path,
             reverse(
-                'transaction-prison-user-list', kwargs={
+                'cashbook:transaction-prison-user-list', kwargs={
                     'user_id': transactions_owner.pk,
                     'prison_id': prison.pk
                 }
@@ -741,7 +741,7 @@ class TransactionsReleaseTestCase(
         )
 
 
-class TransactionsPatchTestCase(
+class CashbookTransactionsPatchTestCase(
     CashbookTransactionRejectsRequestsWithoutPermissionTestMixin,
     BaseTransactionViewTestCase
 ):
@@ -749,7 +749,7 @@ class TransactionsPatchTestCase(
 
     def _get_url(self, user, prison):
         return reverse(
-            'transaction-prison-user-list', kwargs={
+            'cashbook:transaction-prison-user-list', kwargs={
                 'user_id': user.pk,
                 'prison_id': prison.pk
             }
@@ -967,14 +967,14 @@ class TransactionsPatchTestCase(
             )
 
 
-class AdminCreateTransactionsTestCase(
+class BankAdminCreateTransactionsTestCase(
     TransactionRejectsRequestsWithoutPermissionTestMixin,
     BaseTransactionViewTestCase
 ):
     ENDPOINT_VERB = 'post'
 
     def setUp(self):
-        super(AdminCreateTransactionsTestCase, self).setUp()
+        super(BankAdminCreateTransactionsTestCase, self).setUp()
 
         # delete all transactions and logs
         Transaction.objects.all().delete()
@@ -998,7 +998,7 @@ class AdminCreateTransactionsTestCase(
             status=TRANSACTION_STATUS.AVAILABLE
         )
 
-        create_serializer = AdminTransactionView.create_serializer_class()
+        create_serializer = BankAdminTransactionView.create_serializer_class()
         keys = create_serializer.get_fields().keys()
 
         return [

--- a/mtp_api/apps/transaction/urls.py
+++ b/mtp_api/apps/transaction/urls.py
@@ -2,16 +2,17 @@ from django.conf.urls import patterns, url, include
 
 from rest_framework import routers
 
-from .routers import TransactionRouter
+from .routers import CashbookTransactionRouter
 from . import views
 
 
-transaction_router = TransactionRouter()
+cashbook_transaction_router = CashbookTransactionRouter()
+cashbook_transaction_router.register(r'transactions', views.CashbookTransactionView)
 
 admin_transaction_router = routers.DefaultRouter()
-admin_transaction_router.register(r'transactions', views.AdminTransactionView)
+admin_transaction_router.register(r'transactions', views.BankAdminTransactionView)
 
 urlpatterns = patterns('',
     url(r'^bank-admin/', include(admin_transaction_router.urls, namespace='bank-admin')),
-    url(r'^', include(transaction_router.urls)),
+    url(r'^cashbook/', include(cashbook_transaction_router.urls, namespace='cashbook')),
 )


### PR DESCRIPTION
This namespaces the cashbook transactions endpoint:
previously: /transactions/
now: /cashbook/transactions/

so that the context is clear when using them.