### PR TITLE
Cast ids to int when locking

### DIFF
--- a/mtp_api/apps/transaction/api/bank_admin/views.py
+++ b/mtp_api/apps/transaction/api/bank_admin/views.py
@@ -49,7 +49,7 @@ class TransactionView(mixins.CreateModelMixin, mixins.UpdateModelMixin,
                     'errors': [
                         {
                             'msg': 'Some transactions could not be refunded',
-                            'ids': sorted([str(t_id) for t_id in e.args[0]])
+                            'ids': sorted(e.args[0])
                         }
                     ]
                 },

--- a/mtp_api/apps/transaction/api/cashbook/serializers.py
+++ b/mtp_api/apps/transaction/api/cashbook/serializers.py
@@ -15,6 +15,12 @@ class CreditedOnlyTransactionSerializer(serializers.ModelSerializer):
         )
 
 
+class IdsTransactionSerializer(serializers.Serializer):
+    transaction_ids = serializers.ListField(
+       child=serializers.IntegerField()
+    )
+
+
 class TransactionSerializer(serializers.ModelSerializer):
     sender = serializers.CharField(source='sender_name')
 

--- a/mtp_api/apps/transaction/tests/test_cashbook_views.py
+++ b/mtp_api/apps/transaction/tests/test_cashbook_views.py
@@ -519,7 +519,7 @@ class UnlockTransactionTestCase(
         errors = response.data['errors']
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]['msg'], 'Some transactions could not be unlocked.')
-        self.assertEqual(errors[0]['ids'], sorted([str(t_id) for t_id in to_unlock]))
+        self.assertEqual(errors[0]['ids'], sorted(to_unlock))
 
     def test_cannot_unlock_credited_transactions(self):
         logged_in_user = self.prison_clerks[0]
@@ -542,7 +542,7 @@ class UnlockTransactionTestCase(
         errors = response.data['errors']
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]['msg'], 'Some transactions could not be unlocked.')
-        self.assertEqual(errors[0]['ids'], sorted([str(t_id) for t_id in credited_ids]))
+        self.assertEqual(errors[0]['ids'], sorted(credited_ids))
 
 
 class CreditTransactionTestCase(
@@ -637,7 +637,7 @@ class CreditTransactionTestCase(
         errors = response.data['errors']
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]['msg'], 'Some transactions could not be credited.')
-        self.assertEqual(errors[0]['ids'], sorted([str(t_id) for t_id in locked_by_other_user_ids]))
+        self.assertEqual(errors[0]['ids'], sorted(locked_by_other_user_ids))
 
         # nothing changed in db
         self.assertEqual(credited_qs.count(), credited)
@@ -671,7 +671,7 @@ class CreditTransactionTestCase(
         errors = response.data['errors']
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]['msg'], 'Some transactions could not be credited.')
-        self.assertEqual(errors[0]['ids'], sorted([str(t_id) for t_id in available_ids]))
+        self.assertEqual(errors[0]['ids'], sorted(available_ids))
 
         # nothing changed in db
         self.assertEqual(credited_qs.count(), credited)


### PR DESCRIPTION
The cashbook is sending ids as strings but the API is expecting integers.
I could have changed the cashbook but I've noticed that we are using ints everywhere else so I thought it would be cleaner to cast ids to integers in the API unlock view.