### PR TITLE
Fail safe if logged user doesn't manage any prisons

### DIFF
--- a/mtp_api/apps/mtp_auth/serializers.py
+++ b/mtp_api/apps/mtp_auth/serializers.py
@@ -2,14 +2,17 @@ from django.contrib.auth.models import User
 
 from rest_framework import serializers
 
+from .models import PrisonUserMapping
+
 
 class UserSerializer(serializers.ModelSerializer):
     prisons = serializers.SerializerMethodField()
 
     def get_prisons(self, obj):
-        return [
-            prison.pk for prison in obj.prisonusermapping.prisons.all()
-        ]
+        try:
+            return list(obj.prisonusermapping.prisons.values_list('pk', flat=True))
+        except PrisonUserMapping.DoesNotExist:
+            return []
 
     class Meta:
         model = User


### PR DESCRIPTION
This fixes a problem with users (e.g. bank admins) without PrisonUserMapping model. The code is not catching the case and failing silently.