### PR TITLE
Extend bank_admin API to provide additional information

### DIFF
--- a/mtp_api/apps/transaction/api/bank_admin/serializers.py
+++ b/mtp_api/apps/transaction/api/bank_admin/serializers.py
@@ -5,6 +5,7 @@ from rest_framework.fields import IntegerField
 
 from transaction.signals import transaction_created, transaction_refunded
 from transaction.models import Transaction
+from prison.models import Prison
 
 
 class CreateTransactionListSerializer(serializers.ListSerializer):
@@ -88,7 +89,18 @@ class UpdateRefundedTransactionSerializer(serializers.ModelSerializer):
         )
 
 
+class PrisonSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Prison
+        fields = (
+            'nomis_id',
+            'name'
+        )
+
+
 class TransactionSerializer(serializers.ModelSerializer):
+    prison = PrisonSerializer(required=False)
 
     class Meta:
         model = Transaction
@@ -107,6 +119,7 @@ class TransactionSerializer(serializers.ModelSerializer):
 
 
 class ReconcileTransactionSerializer(serializers.ModelSerializer):
+    prison = PrisonSerializer(required=False)
 
     class Meta:
         model = Transaction

--- a/mtp_api/apps/transaction/tests/test_bank_admin_views.py
+++ b/mtp_api/apps/transaction/tests/test_bank_admin_views.py
@@ -339,6 +339,9 @@ class GetTransactionsAsBankAdminTestCase(
                             'amount' in t and
                             'credited' in t and
                             'refunded' in t)
+            if t['prison'] is not None:
+                self.assertTrue('nomis_id' in t['prison'] and
+                                'name' in t['prison'])
 
     def _assert_hidden_fields_absent(self, results):
         for t in results:


### PR DESCRIPTION
This is required for reconciliation - prison name as well as code is required.