### PR TITLE
Correct the URL used for refunding transactions

### DIFF
--- a/mtp_api/apps/transaction/api/bank_admin/urls.py
+++ b/mtp_api/apps/transaction/api/bank_admin/urls.py
@@ -1,0 +1,11 @@
+from django.conf.urls import patterns, url
+
+from . import views
+
+urlpatterns = patterns('',
+    url(r'^transactions/$', views.TransactionView.as_view({
+        'get': 'list',
+        'post': 'create',
+        'patch': 'patch_refunded'
+    }), name='transaction-list'),
+)

--- a/mtp_api/apps/transaction/api/bank_admin/views.py
+++ b/mtp_api/apps/transaction/api/bank_admin/views.py
@@ -1,7 +1,6 @@
 from rest_framework import mixins, viewsets, status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.decorators import list_route
 from rest_framework.exceptions import ParseError
 
 from mtp_auth.permissions import BankAdminClientIDPermissions
@@ -39,7 +38,6 @@ class TransactionView(mixins.CreateModelMixin, mixins.UpdateModelMixin,
 
         return queryset
 
-    @list_route(methods=['patch'])
     def patch_refunded(self, request, *args, **kwargs):
         try:
             return self.partial_update(request, *args, **kwargs)

--- a/mtp_api/apps/transaction/tests/test_bank_admin_views.py
+++ b/mtp_api/apps/transaction/tests/test_bank_admin_views.py
@@ -151,7 +151,7 @@ class UpdateTransactionsTestCase(
         return self.refund_bank_admins[0]
 
     def _get_url(self, *args, **kwargs):
-        return reverse('bank_admin:transaction-patch-refunded')
+        return reverse('bank_admin:transaction-list')
 
     def _get_transactions(self, tot=30):
         transactions = generate_transactions(transaction_batch=tot)

--- a/mtp_api/apps/transaction/urls.py
+++ b/mtp_api/apps/transaction/urls.py
@@ -1,16 +1,10 @@
 from django.conf.urls import patterns, url, include
 
-from rest_framework import routers
-
 from .api.cashbook import urls as cashbook_urls
-from .api.bank_admin import views as bank_admin_views
+from .api.bank_admin import urls as bank_admin_urls
 
-
-admin_transaction_router = routers.DefaultRouter()
-admin_transaction_router.register(r'transactions', bank_admin_views.TransactionView,
-                                  base_name='transaction')
 
 urlpatterns = patterns('',
-    url(r'^bank_admin/', include(admin_transaction_router.urls, namespace='bank_admin')),
+    url(r'^bank_admin/', include(bank_admin_urls, namespace='bank_admin')),
     url(r'^cashbook/', include(cashbook_urls, namespace='cashbook')),
 )


### PR DESCRIPTION
In the previous configuration, the route for refunding transactions
was being set to /transactions/patch_refunded rather than the
intended /transactions/.