### PR TITLE
Change prisoner locations endpoint URL for slumber compatibility

### DIFF
--- a/mtp_api/apps/prison/urls.py
+++ b/mtp_api/apps/prison/urls.py
@@ -5,7 +5,7 @@ from rest_framework import routers
 from . import views
 
 router = routers.DefaultRouter()
-router.register(r'prisoner-locations', views.PrisonerLocationView)
+router.register(r'prisoner_locations', views.PrisonerLocationView)
 
 urlpatterns = patterns('',
     url(r'^', include(router.urls)),


### PR DESCRIPTION
As slumber works by converting the attributes of the client object
that are accessed into the URL, and an attribute cannot contain a
hyphen, we must change the URL to contain an underscore instead.