### PR TITLE
Transaction.prison updated from prisoner location upload

### DIFF
--- a/mtp_api/apps/prison/serializers.py
+++ b/mtp_api/apps/prison/serializers.py
@@ -2,6 +2,8 @@ from django.db import transaction
 
 from rest_framework import serializers
 
+from transaction.signals import transaction_prisons_need_updating
+
 from .models import PrisonerLocation
 
 
@@ -15,7 +17,11 @@ class PrisonerLocationListSerializer(serializers.ListSerializer):
 
         # delete all current records and insert new batch
         PrisonerLocation.objects.all().delete()
-        return PrisonerLocation.objects.bulk_create(locations)
+        objects = PrisonerLocation.objects.bulk_create(locations)
+
+        transaction_prisons_need_updating.send(sender=PrisonerLocation)
+
+        return objects
 
 
 class PrisonerLocationSerializer(serializers.ModelSerializer):

--- a/mtp_api/apps/prison/tests/utils.py
+++ b/mtp_api/apps/prison/tests/utils.py
@@ -1,8 +1,12 @@
 import datetime
 import random
 import string
+from itertools import cycle
 
 from django.utils.crypto import get_random_string
+from django.contrib.auth.models import User
+
+from prison.models import Prison, PrisonerLocation
 
 
 def random_prisoner_dob():
@@ -20,3 +24,35 @@ def random_prisoner_number():
         get_random_string(allowed_chars=string.digits, length=4),
         get_random_string(allowed_chars=string.ascii_uppercase, length=2)
     )
+
+
+def get_prisoner_location_creator():
+    """
+    Returns a function(prisoner_number, prisoner_dob) which when called returns:
+        (is_valid, PrisonerLocation instance)
+    """
+    prisons = cycle(list(Prison.objects.all()))
+    index = cycle(range(1, 11))
+
+    created_by = User.objects.all()[0]
+
+    def make_prisoner_location(prisoner_number, prisoner_dob):
+        if not prisoner_number or not prisoner_dob:
+            return (False, None)
+
+        # is_invalid = next(index) % 10 == 0  # 10% invalid (not implemented yet)
+        is_invalid = False
+
+        data = {
+            'created_by': created_by,
+            'prisoner_number': prisoner_number,
+            'prisoner_dob': prisoner_dob,
+            'prison': next(prisons)
+        }
+
+        if is_invalid:
+            data['prisoner_dob'] = data['prisoner_dob'] + datetime.timedelta(days=1)
+
+        return (not is_invalid, PrisonerLocation.objects.create(**data))
+
+    return make_prisoner_location

--- a/mtp_api/apps/transaction/api/bank_admin/serializers.py
+++ b/mtp_api/apps/transaction/api/bank_admin/serializers.py
@@ -3,7 +3,8 @@ from django.db import transaction
 from rest_framework import serializers
 from rest_framework.fields import IntegerField
 
-from transaction.signals import transaction_created, transaction_refunded
+from transaction.signals import transaction_created, transaction_refunded, \
+    transaction_prisons_need_updating
 from transaction.models import Transaction
 from prison.models import Prison
 
@@ -25,6 +26,8 @@ class CreateTransactionListSerializer(serializers.ListSerializer):
             )
 
             transactions.append(transaction)
+
+        transaction_prisons_need_updating.send(sender=Transaction)
 
         return transactions
 

--- a/mtp_api/apps/transaction/api/cashbook/views.py
+++ b/mtp_api/apps/transaction/api/cashbook/views.py
@@ -17,6 +17,7 @@ from prison.models import Prison
 
 from transaction.constants import TRANSACTION_STATUS, LOCK_LIMIT
 from transaction.models import Transaction
+from transaction.signals import transaction_prisons_need_updating
 
 from .serializers import TransactionSerializer, \
     CreditedOnlyTransactionSerializer, \
@@ -209,6 +210,8 @@ class UnlockTransactions(TransactionViewMixin, APIView):
                 )
             for t in to_update:
                 t.unlock(by_user=request.user)
+
+        transaction_prisons_need_updating.send(sender=Transaction)
 
         redirect_url = '{url}?user={user}&status={status}'.format(
             url=reverse('cashbook:transaction-list'),

--- a/mtp_api/apps/transaction/models.py
+++ b/mtp_api/apps/transaction/models.py
@@ -44,13 +44,13 @@ class Transaction(TimeStampedModel):
         TRANSACTION_STATUS.LOCKED:
             {'owner__isnull': False, 'credited': False, 'refunded': False},
         TRANSACTION_STATUS.AVAILABLE:
-            {'owner__isnull': True, 'credited': False, 'refunded': False},
+            {'prison__isnull': False, 'owner__isnull': True, 'credited': False, 'refunded': False},
         TRANSACTION_STATUS.CREDITED:
             {'credited': True},
         TRANSACTION_STATUS.REFUNDED:
             {'refunded': True},
         TRANSACTION_STATUS.REFUND_PENDING:
-            {'prisoner_number': '', 'refunded': False}
+            {'prison__isnull': True, 'owner__isnull': True, 'credited': False, 'refunded': False},
     }
 
     objects = TransactionQuerySet.as_manager()

--- a/mtp_api/apps/transaction/models.py
+++ b/mtp_api/apps/transaction/models.py
@@ -9,7 +9,8 @@ from prison.models import Prison
 from .constants import TRANSACTION_STATUS, LOG_ACTIONS
 from .managers import TransactionQuerySet, LogManager
 from .signals import transaction_created, transaction_locked, \
-    transaction_unlocked, transaction_credited, transaction_refunded
+    transaction_unlocked, transaction_credited, transaction_refunded, \
+    transaction_prisons_need_updating
 
 
 class Transaction(TimeStampedModel):
@@ -135,3 +136,8 @@ def transaction_credited_receiver(sender, transaction, by_user, credited=True, *
 @receiver(transaction_refunded)
 def transaction_refunded_receiver(sender, transaction, by_user, **kwargs):
     Log.objects.transaction_refunded(transaction, by_user)
+
+
+@receiver(transaction_prisons_need_updating)
+def update_transaction_prisons(*args, **kwargs):
+    Transaction.objects.update_prisons()

--- a/mtp_api/apps/transaction/signals.py
+++ b/mtp_api/apps/transaction/signals.py
@@ -5,3 +5,5 @@ transaction_locked = Signal(providing_args=['transaction', 'by_user'])
 transaction_unlocked = Signal(providing_args=['transaction', 'by_user'])
 transaction_credited = Signal(providing_args=['transaction', 'by_user'])
 transaction_refunded = Signal(providing_args=['transaction', 'by_user'])
+
+transaction_prisons_need_updating = Signal()

--- a/mtp_api/apps/transaction/tests/test_bank_admin_views.py
+++ b/mtp_api/apps/transaction/tests/test_bank_admin_views.py
@@ -1,4 +1,5 @@
 import mock
+
 from django.core.urlresolvers import reverse
 from rest_framework import status as http_status
 
@@ -6,7 +7,7 @@ from transaction.models import Transaction, Log
 from transaction.constants import TRANSACTION_STATUS, LOG_ACTIONS
 from transaction.api.bank_admin.serializers import CreateTransactionSerializer
 
-from .utils import generate_transactions_data, generate_transactions
+from .utils import generate_initial_transactions_data, generate_transactions
 from .test_base import BaseTransactionViewTestCase, \
     TransactionRejectsRequestsWithoutPermissionTestMixin
 
@@ -36,10 +37,7 @@ class CreateTransactionsTestCase(
         return reverse('bank_admin:transaction-list')
 
     def _get_transactions_data(self, tot=30):
-        data_list = generate_transactions_data(
-            transaction_batch=tot,
-            status=TRANSACTION_STATUS.AVAILABLE
-        )
+        data_list = generate_initial_transactions_data(tot=tot)
 
         serializer = CreateTransactionSerializer()
         keys = serializer.get_fields().keys()

--- a/mtp_api/apps/transaction/tests/test_prison_updates.py
+++ b/mtp_api/apps/transaction/tests/test_prison_updates.py
@@ -1,0 +1,217 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from core.tests.utils import make_test_users
+
+from prison.models import Prison, PrisonerLocation
+from prison.tests.utils import random_prisoner_number, random_prisoner_dob
+
+from transaction.models import Transaction
+from transaction.signals import transaction_prisons_need_updating
+
+
+class BaseUpdatePrisonsTestCase(TestCase):
+    fixtures = [
+        'initial_groups.json',
+        'test_prisons.json'
+    ]
+
+    def _get_transaction_data(self):
+        return {
+            'amount': 1000,
+            'prison': None,
+            'received_at': timezone.now().replace(microsecond=0),
+            'sender_sort_code': '123456',
+            'sender_account_number': '12345678',
+            'sender_name': 'Sender Name'
+        }
+
+    def setUp(self):
+        super(BaseUpdatePrisonsTestCase, self).setUp()
+        make_test_users()
+
+        self.transaction = Transaction.objects.create(
+            **self._get_transaction_data()
+        )
+
+
+class UpdatePrisonsOnAvailableTransactionsTestCase(BaseUpdatePrisonsTestCase):
+
+    def _get_transaction_data(self):
+        data = super(UpdatePrisonsOnAvailableTransactionsTestCase, self)._get_transaction_data()
+        data.update({
+            'prison': Prison.objects.first(),
+            'prisoner_number': random_prisoner_number(),
+            'prisoner_dob': random_prisoner_dob(),
+            'owner': None,
+            'credited': False,
+            'refunded': False
+        })
+        return data
+
+    def test_without_prisoner_locations_sets_prison_to_None(self):
+        self.assertNotEqual(self.transaction.prison, None)
+
+        transaction_prisons_need_updating.send(sender=None)
+
+        self.transaction.refresh_from_db()
+        self.assertEqual(self.transaction.prison, None)
+
+    def test_with_prisoner_locations_overrides_prison(self):
+        self.assertNotEqual(self.transaction.prison, None)
+
+        existing_prison = self.transaction.prison
+        new_prison = Prison.objects.exclude(pk=existing_prison.pk).first()
+
+        PrisonerLocation.objects.create(
+            created_by=User.objects.first(),
+            prisoner_number=self.transaction.prisoner_number,
+            prisoner_dob=self.transaction.prisoner_dob,
+            prison=new_prison
+        )
+
+        transaction_prisons_need_updating.send(sender=None)
+
+        self.transaction.refresh_from_db()
+        self.assertEqual(self.transaction.prison.pk, new_prison.pk)
+
+
+class UpdatePrisonsOnLockedTransactionsTestCase(BaseUpdatePrisonsTestCase):
+
+    def _get_transaction_data(self):
+        data = super(UpdatePrisonsOnLockedTransactionsTestCase, self)._get_transaction_data()
+        data.update({
+            'prison': Prison.objects.first(),
+            'prisoner_number': random_prisoner_number(),
+            'prisoner_dob': random_prisoner_dob(),
+            'owner': User.objects.first(),
+            'credited': False,
+            'refunded': False
+        })
+        return data
+
+    def test_prisoner_location_doesnt_update_transaction(self):
+        self.assertNotEqual(self.transaction.prison, None)
+
+        existing_prison = self.transaction.prison
+        other_prison = Prison.objects.exclude(pk=existing_prison.pk).first()
+
+        PrisonerLocation.objects.create(
+            created_by=User.objects.first(),
+            prisoner_number=self.transaction.prisoner_number,
+            prisoner_dob=self.transaction.prisoner_dob,
+            prison=other_prison
+        )
+
+        transaction_prisons_need_updating.send(sender=None)
+
+        self.transaction.refresh_from_db()
+        self.assertEqual(self.transaction.prison.pk, existing_prison.pk)
+
+
+class UpdatePrisonsOnCreditedTransactionsTestcase(BaseUpdatePrisonsTestCase):
+
+    def _get_transaction_data(self):
+        data = super(UpdatePrisonsOnCreditedTransactionsTestcase, self)._get_transaction_data()
+        data.update({
+            'prison': Prison.objects.first(),
+            'prisoner_number': random_prisoner_number(),
+            'prisoner_dob': random_prisoner_dob(),
+            'owner': User.objects.first(),
+            'credited': True,
+            'refunded': False
+        })
+        return data
+
+    def test_prisoner_location_doesnt_update_transaction(self):
+        self.assertNotEqual(self.transaction.prison, None)
+
+        existing_prison = self.transaction.prison
+        other_prison = Prison.objects.exclude(pk=existing_prison.pk).first()
+
+        PrisonerLocation.objects.create(
+            created_by=User.objects.first(),
+            prisoner_number=self.transaction.prisoner_number,
+            prisoner_dob=self.transaction.prisoner_dob,
+            prison=other_prison
+        )
+
+        transaction_prisons_need_updating.send(sender=None)
+
+        self.transaction.refresh_from_db()
+        self.assertEqual(self.transaction.prison.pk, existing_prison.pk)
+
+
+class UpdatePrisonsOnRefundedTransactionsTestcase(BaseUpdatePrisonsTestCase):
+
+    def _get_transaction_data(self):
+        data = super(UpdatePrisonsOnRefundedTransactionsTestcase, self)._get_transaction_data()
+        data.update({
+            'prison': None,
+            'prisoner_number': random_prisoner_number(),
+            'prisoner_dob': random_prisoner_dob(),
+            'owner': None,
+            'credited': False,
+            'refunded': True
+        })
+        return data
+
+    def test_prisoner_location_doesnt_update_transaction(self):
+        self.assertEqual(self.transaction.prison, None)
+        self.assertTrue(self.transaction.refunded)
+
+        prison = Prison.objects.first()
+
+        PrisonerLocation.objects.create(
+            created_by=User.objects.first(),
+            prisoner_number=self.transaction.prisoner_number,
+            prisoner_dob=self.transaction.prisoner_dob,
+            prison=prison
+        )
+
+        transaction_prisons_need_updating.send(sender=None)
+
+        self.transaction.refresh_from_db()
+        self.assertEqual(self.transaction.prison, None)
+        self.assertTrue(self.transaction.refunded)
+
+
+class UpdatePrisonsOnRefundPendingTransactionsTestcase(BaseUpdatePrisonsTestCase):
+
+    def _get_transaction_data(self):
+        data = super(UpdatePrisonsOnRefundPendingTransactionsTestcase, self)._get_transaction_data()
+        data.update({
+            'prison': None,
+            'prisoner_number': random_prisoner_number(),
+            'prisoner_dob': random_prisoner_dob(),
+            'owner': None,
+            'credited': False,
+            'refunded': False
+        })
+        return data
+
+    def test_without_prisoner_locations_doesnt_set_prison(self):
+        self.assertEqual(self.transaction.prison, None)
+
+        transaction_prisons_need_updating.send(sender=None)
+
+        self.transaction.refresh_from_db()
+        self.assertEqual(self.transaction.prison, None)
+
+    def test_with_prisoner_locations_sets_prison(self):
+        self.assertEqual(self.transaction.prison, None)
+
+        prison = Prison.objects.first()
+
+        PrisonerLocation.objects.create(
+            created_by=User.objects.first(),
+            prisoner_number=self.transaction.prisoner_number,
+            prisoner_dob=self.transaction.prisoner_dob,
+            prison=prison
+        )
+
+        transaction_prisons_need_updating.send(sender=None)
+
+        self.transaction.refresh_from_db()
+        self.assertEqual(self.transaction.prison.pk, prison.pk)

--- a/mtp_api/apps/transaction/tests/utils.py
+++ b/mtp_api/apps/transaction/tests/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import random
+from itertools import cycle
 
 from django.utils import timezone
 from django.utils.crypto import get_random_string
@@ -10,40 +11,8 @@ from prison.models import Prison
 from transaction.models import Transaction
 from transaction.constants import TRANSACTION_STATUS
 
-
-from prison.tests.utils import random_prisoner_number, random_prisoner_dob
-
-
-class PrisonChooser(object):
-
-    def __init__(self):
-        self.prisons = Prison.objects.all()
-        self.clerks_per_prison = {}
-        for prison in self.prisons:
-            user_ids = prison.prisonusermapping_set.values_list('user', flat=True)
-            self.clerks_per_prison[prison.pk] = {
-                'users': User.objects.filter(id__in=user_ids),
-                'index': 0
-            }
-        self.index = 0
-
-    def _choose(self, l, index):
-        item = l[index]
-        index += 1
-        if index >= len(l):
-            index = 0
-        return (item, index)
-
-    def choose_prison(self):
-        prison, index = self._choose(self.prisons, self.index)
-        self.index = index
-        return prison
-
-    def choose_user(self, prison):
-        data = self.clerks_per_prison[prison.pk]
-        user, index = self._choose(data['users'], data['index'])
-        data['index'] = index
-        return user
+from prison.tests.utils import random_prisoner_number, random_prisoner_dob, \
+    get_prisoner_location_creator
 
 
 def random_reference(prisoner_number=None, prisoner_dob=None):
@@ -58,7 +27,6 @@ def random_reference(prisoner_number=None, prisoner_dob=None):
 def generate_initial_transactions_data(tot=50):
     data_list = []
 
-    prison_chooser = PrisonChooser()
     now = timezone.now().replace(microsecond=0)
 
     for transaction_counter in range(1, tot+1):
@@ -75,7 +43,6 @@ def generate_initial_transactions_data(tot=50):
 
         data = {
             'amount': random.randint(1000, 30000),
-            'prison': None,
             'received_at': now - datetime.timedelta(
                 minutes=random.randint(0, 10000)
             ),
@@ -88,9 +55,7 @@ def generate_initial_transactions_data(tot=50):
         }
 
         if include_prisoner_info:
-            prison = prison_chooser.choose_prison()
             data.update({
-                'prison': prison,
                 'prisoner_number': random_prisoner_number(),
                 'prisoner_dob': random_prisoner_dob()
             })
@@ -107,39 +72,56 @@ def generate_initial_transactions_data(tot=50):
     return data_list
 
 
-def generate_transactions_data(transaction_batch=50):
+def generate_transactions(transaction_batch=50):
+    def get_owner_and_status_chooser():
+        clerks_per_prison = {}
+        for prison in Prison.objects.all():
+            user_ids = prison.prisonusermapping_set.values_list('user', flat=True)
+            clerks_per_prison[prison.pk] = (
+                cycle(list(User.objects.filter(id__in=user_ids))),
+                cycle([
+                    TRANSACTION_STATUS.LOCKED,
+                    TRANSACTION_STATUS.AVAILABLE,
+                    TRANSACTION_STATUS.CREDITED
+                ])
+            )
+
+        def internal_function(prison):
+            user, status = clerks_per_prison[prison.pk]
+            return (next(user), next(status))
+        return internal_function
+
     data_list = generate_initial_transactions_data(
         tot=transaction_batch
     )
 
-    prison_chooser = PrisonChooser()
+    location_creator = get_prisoner_location_creator()
+    onwer_status_chooser = get_owner_and_status_chooser()
 
+    transactions = []
     for transaction_counter, data in enumerate(data_list, start=1):
-        prison = data['prison']
-
-        if prison:
+        is_valid, prisoner_location = location_creator(
+            data.get('prisoner_number'), data.get('prisoner_dob')
+        )
+        if is_valid:
             # randomly choose the state of the transaction
-            trans_status = random.choice(
-                [
-                    TRANSACTION_STATUS.LOCKED,
-                    TRANSACTION_STATUS.AVAILABLE,
-                    TRANSACTION_STATUS.CREDITED
-                ]
-            )
+            prison = prisoner_location.prison
+            owner, t_status = onwer_status_chooser(prison)
 
-            if trans_status == TRANSACTION_STATUS.LOCKED:
+            data['prison'] = prison
+            if t_status == TRANSACTION_STATUS.LOCKED:
                 data.update({
-                    'owner': prison_chooser.choose_user(prison),
+                    'owner': owner,
                     'credited': False
                 })
-            elif trans_status == TRANSACTION_STATUS.AVAILABLE:
+            elif t_status == TRANSACTION_STATUS.AVAILABLE:
                 data.update({
                     'owner': None,
                     'credited': False
                 })
-            elif trans_status == TRANSACTION_STATUS.CREDITED:
+            elif t_status == TRANSACTION_STATUS.CREDITED:
                 data.update({
-                    'owner': prison_chooser.choose_user(prison),
+                    'owner': owner,
                     'credited': True
                 })
         else:
@@ -148,17 +130,8 @@ def generate_transactions_data(transaction_batch=50):
             else:
                 data.update({'refunded': False})
 
-    return data_list
-
-
-def generate_transactions(transaction_batch=30):
-    data_list = generate_transactions_data(
-        transaction_batch=transaction_batch
-    )
-
-    transactions = []
-    for data in data_list:
         transactions.append(
             Transaction.objects.create(**data)
         )
+
     return transactions


### PR DESCRIPTION
This changes the logic behind the Transaction.prison field.

When new transactions get uploaded and created, they don't have the the notion of 'assigned prison'. This information is in an extra file called *prisoner location upload* containing a list of (prisoner_number, prisoner_dob, prison).
The actual prison of a transaction is the left outer join between the tables `transaction` and `prisoner location` on `(prisoner_number, prisoner_dob)`.

I tried changing the queries so that the prison would be calculated by executing the above join every time but it wasn't working well so we decided to pre-calculate the prison and store it in the `Transaction.prison` field instead.

As transactions and prisoner location records are created at different times though, it was hard to determine when to update prison field so we decided to update it either when a new transaction gets created AND/OR when an new prisoner location file gets uploaded.

During this process, we ignore the transactions which have been locked, credited or refunded so that we don't change any work in progress.
Finally, if a transaction gets unlocked without being credited or refunded, we update the prison field to make sure that we have the latest version.

I had to change the test data as we need dummy prisoner location records now when creating dummy transactions.