### PR TITLE
Add mommy_recipes to base requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,3 +8,4 @@ django-oauth-toolkit==0.8.1
 drf-extensions==0.2.7
 django-rest-swagger==0.3.2
 django-extended-choices==1.0.4
+model-mommy==1.2.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,6 +2,5 @@
 -r base.txt
 django-extensions==1.5.0
 Werkzeug==0.10.4
-model-mommy==1.2.4
 mock==1.3.0
 six==1.9.0


### PR DESCRIPTION
This was previously only included in the dev requirements, but is
required if we wish to be able to load test data automatically as
a docker task.