### PR TITLE
Add general_ledger_code field to prison table

### DIFF
--- a/mtp_api/apps/prison/fixtures/test_prisons.json
+++ b/mtp_api/apps/prison/fixtures/test_prisons.json
@@ -4,7 +4,8 @@
     "fields": {
         "created": "2015-06-17T13:47:18.099Z",
         "modified": "2015-06-17T13:47:18.100Z",
-        "name": "Prison 1"
+        "name": "Prison 1",
+        "general_ledger_code": "042"
     },
     "pk": "IXB"
 },
@@ -13,7 +14,8 @@
     "fields": {
         "created": "2015-06-17T13:47:31.283Z",
         "modified": "2015-06-17T13:47:31.283Z",
-        "name": "Prison 2"
+        "name": "Prison 2",
+        "general_ledger_code": "015"
     },
     "pk": "INP"
 }

--- a/mtp_api/apps/prison/migrations/0005_prison_general_ledger_code.py
+++ b/mtp_api/apps/prison/migrations/0005_prison_general_ledger_code.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('prison', '0004_auto_20150811_1458'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='prison',
+            name='general_ledger_code',
+            field=models.CharField(max_length=3, default='000'),
+            preserve_default=False,
+        ),
+    ]

--- a/mtp_api/apps/prison/models.py
+++ b/mtp_api/apps/prison/models.py
@@ -6,6 +6,7 @@ from model_utils.models import TimeStampedModel
 
 class Prison(TimeStampedModel):
     nomis_id = models.CharField(max_length=3, primary_key=True)
+    general_ledger_code = models.CharField(max_length=3)
     name = models.CharField(max_length=500)
 
     def __str__(self):

--- a/mtp_api/apps/prison/serializers.py
+++ b/mtp_api/apps/prison/serializers.py
@@ -4,7 +4,18 @@ from rest_framework import serializers
 
 from transaction.signals import transaction_prisons_need_updating
 
-from .models import PrisonerLocation
+from .models import PrisonerLocation, Prison
+
+
+class PrisonSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Prison
+        fields = (
+            'nomis_id',
+            'general_ledger_code',
+            'name'
+        )
 
 
 class PrisonerLocationListSerializer(serializers.ListSerializer):

--- a/mtp_api/apps/transaction/api/bank_admin/serializers.py
+++ b/mtp_api/apps/transaction/api/bank_admin/serializers.py
@@ -6,7 +6,7 @@ from rest_framework.fields import IntegerField
 from transaction.signals import transaction_created, transaction_refunded, \
     transaction_prisons_need_updating
 from transaction.models import Transaction
-from prison.models import Prison
+from prison.serializers import PrisonSerializer
 
 
 class CreateTransactionListSerializer(serializers.ListSerializer):
@@ -89,16 +89,6 @@ class UpdateRefundedTransactionSerializer(serializers.ModelSerializer):
         fields = (
             'id',
             'refunded'
-        )
-
-
-class PrisonSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = Prison
-        fields = (
-            'nomis_id',
-            'name'
         )
 
 

--- a/mtp_api/apps/transaction/tests/test_bank_admin_views.py
+++ b/mtp_api/apps/transaction/tests/test_bank_admin_views.py
@@ -350,6 +350,7 @@ class GetTransactionsAsBankAdminTestCase(
                             'refunded' in t)
             if t['prison'] is not None:
                 self.assertTrue('nomis_id' in t['prison'] and
+                                'general_ledger_code' in t['prison'] and
                                 'name' in t['prison'])
 
     def _assert_hidden_fields_absent(self, results):


### PR DESCRIPTION
Phoenix uses a different code to identify prisons to NOMIS,
so this code, the general ledger code, must also be recorded
in the database and returned by the API for the purpose
of reconciliation with Phoenix.