### PR TITLE
Return the user's permissions in the user data response

### DIFF
--- a/mtp_api/apps/mtp_auth/serializers.py
+++ b/mtp_api/apps/mtp_auth/serializers.py
@@ -7,12 +7,16 @@ from .models import PrisonUserMapping
 
 class UserSerializer(serializers.ModelSerializer):
     prisons = serializers.SerializerMethodField()
+    permissions = serializers.SerializerMethodField()
 
     def get_prisons(self, obj):
         try:
             return list(obj.prisonusermapping.prisons.values_list('pk', flat=True))
         except PrisonUserMapping.DoesNotExist:
             return []
+
+    def get_permissions(self, obj):
+        return obj.get_all_permissions()
 
     class Meta:
         model = User
@@ -21,5 +25,6 @@ class UserSerializer(serializers.ModelSerializer):
             'username',
             'first_name',
             'last_name',
-            'prisons'
+            'prisons',
+            'permissions'
         )


### PR DESCRIPTION
Add the user's object permissions to the response body
of the user lookup endpoint in order to allow front-end
applications to control display of actions that the user
can perform.