### PR TITLE
Add prisoner name

### DIFF
--- a/mtp_api/apps/core/tests/utils.py
+++ b/mtp_api/apps/core/tests/utils.py
@@ -9,7 +9,7 @@ from mtp_auth.constants import CASHBOOK_OAUTH_CLIENT_ID, \
     BANK_ADMIN_OAUTH_CLIENT_ID, PRISONER_LOCATION_OAUTH_CLIENT_ID
 
 
-def make_test_users(clerks_per_prison=1):
+def make_test_users(clerks_per_prison=2):
     # prison clerks
     prison_clerks = []
     for prison in Prison.objects.all():

--- a/mtp_api/apps/prison/migrations/0006_prisonerlocation_prisoner_name.py
+++ b/mtp_api/apps/prison/migrations/0006_prisonerlocation_prisoner_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('prison', '0005_prison_general_ledger_code'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='prisonerlocation',
+            name='prisoner_name',
+            field=models.CharField(max_length=250, blank=True),
+        ),
+    ]

--- a/mtp_api/apps/prison/models.py
+++ b/mtp_api/apps/prison/models.py
@@ -16,6 +16,7 @@ class Prison(TimeStampedModel):
 class PrisonerLocation(TimeStampedModel):
     created_by = models.ForeignKey(settings.AUTH_USER_MODEL)
 
+    prisoner_name = models.CharField(blank=True, max_length=250)
     prisoner_number = models.CharField(max_length=250)
     prisoner_dob = models.DateField()
 

--- a/mtp_api/apps/prison/tests/utils.py
+++ b/mtp_api/apps/prison/tests/utils.py
@@ -26,6 +26,15 @@ def random_prisoner_number():
     )
 
 
+def random_prisoner_name():
+    return '%s%s %s%s' % (
+        get_random_string(allowed_chars=string.ascii_uppercase, length=1),
+        get_random_string(allowed_chars=string.ascii_lowercase, length=4),
+        get_random_string(allowed_chars=string.ascii_uppercase, length=1),
+        get_random_string(allowed_chars=string.ascii_lowercase, length=4),
+    )
+
+
 def get_prisoner_location_creator():
     """
     Returns a function(prisoner_number, prisoner_dob) which when called returns:
@@ -36,7 +45,7 @@ def get_prisoner_location_creator():
 
     created_by = User.objects.all()[0]
 
-    def make_prisoner_location(prisoner_number, prisoner_dob):
+    def make_prisoner_location(prisoner_name, prisoner_number, prisoner_dob):
         if not prisoner_number or not prisoner_dob:
             return (False, None)
 
@@ -45,6 +54,7 @@ def get_prisoner_location_creator():
 
         data = {
             'created_by': created_by,
+            'prisoner_name': prisoner_name,
             'prisoner_number': prisoner_number,
             'prisoner_dob': prisoner_dob,
             'prison': next(prisons)

--- a/mtp_api/apps/transaction/api/cashbook/serializers.py
+++ b/mtp_api/apps/transaction/api/cashbook/serializers.py
@@ -33,7 +33,7 @@ class TransactionSerializer(serializers.ModelSerializer):
             'sender',
             'received_at',
             'prison',
-
+            'prisoner_name',
             'owner',
             'credited',
         )

--- a/mtp_api/apps/transaction/managers.py
+++ b/mtp_api/apps/transaction/managers.py
@@ -27,7 +27,8 @@ class TransactionQuerySet(models.QuerySet):
         cursor = connection.cursor()
 
         cursor.execute(
-            "UPDATE transaction_transaction SET prison_id = pl.prison_id "
+            "UPDATE transaction_transaction "
+            "SET prison_id = pl.prison_id, prisoner_name = pl.prisoner_name "
             "FROM transaction_transaction AS t LEFT OUTER JOIN prison_prisonerlocation AS pl "
             "ON t.prisoner_number = pl.prisoner_number AND t.prisoner_dob = pl.prisoner_dob "
             "WHERE t.owner_id IS NULL AND t.credited is False AND t.refunded is False "

--- a/mtp_api/apps/transaction/migrations/0013_transaction_prisoner_name.py
+++ b/mtp_api/apps/transaction/migrations/0013_transaction_prisoner_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transaction', '0012_remove_transaction_upload_counter'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='transaction',
+            name='prisoner_name',
+            field=models.CharField(max_length=250, null=True, blank=True),
+        ),
+    ]

--- a/mtp_api/apps/transaction/models.py
+++ b/mtp_api/apps/transaction/models.py
@@ -15,6 +15,7 @@ from .signals import transaction_created, transaction_locked, \
 
 class Transaction(TimeStampedModel):
     prison = models.ForeignKey(Prison, blank=True, null=True)
+    prisoner_name = models.CharField(blank=True, null=True, max_length=250)
 
     prisoner_number = models.CharField(blank=True, max_length=250)
     prisoner_dob = models.DateField(blank=True, null=True)

--- a/mtp_api/apps/transaction/tests/utils.py
+++ b/mtp_api/apps/transaction/tests/utils.py
@@ -12,7 +12,7 @@ from transaction.models import Transaction
 from transaction.constants import TRANSACTION_STATUS
 
 from prison.tests.utils import random_prisoner_number, random_prisoner_dob, \
-    get_prisoner_location_creator
+    get_prisoner_location_creator, random_prisoner_name
 
 
 def random_reference(prisoner_number=None, prisoner_dob=None):
@@ -56,6 +56,7 @@ def generate_initial_transactions_data(tot=50):
 
         if include_prisoner_info:
             data.update({
+                'prisoner_name': random_prisoner_name(),
                 'prisoner_number': random_prisoner_number(),
                 'prisoner_dob': random_prisoner_dob()
             })
@@ -101,7 +102,8 @@ def generate_transactions(transaction_batch=50):
     transactions = []
     for transaction_counter, data in enumerate(data_list, start=1):
         is_valid, prisoner_location = location_creator(
-            data.get('prisoner_number'), data.get('prisoner_dob')
+            data.get('prisoner_name'), data.get('prisoner_number'),
+            data.get('prisoner_dob')
         )
         if is_valid:
             # randomly choose the state of the transaction


### PR DESCRIPTION
Add prisoner name (sourced from the prisoner location upload) to the models. Will be included in the list of transactions received by the cashbook application.

Bonus commit: make two test clerks per prison.