### PR TITLE
Only allow users associated with a client to log in to it

### DIFF
--- a/mtp_api/apps/core/management/commands/load_test_data.py
+++ b/mtp_api/apps/core/management/commands/load_test_data.py
@@ -2,8 +2,7 @@ from django.core.management.base import BaseCommand
 from django.core.management import call_command
 from django.contrib.auth.models import User
 
-from core.tests.utils import make_test_users, \
-    make_test_oauth_applications
+from core.tests.utils import make_test_users
 
 from transaction.tests.utils import generate_transactions
 
@@ -19,7 +18,5 @@ class Command(BaseCommand):
 
         User.objects.all().delete()
         make_test_users()
-
-        make_test_oauth_applications()
 
         generate_transactions(transaction_batch=100)

--- a/mtp_api/apps/core/tests/utils.py
+++ b/mtp_api/apps/core/tests/utils.py
@@ -2,6 +2,7 @@ from oauth2_provider.models import Application
 
 from django.contrib.auth.models import User
 
+from mtp_auth.models import ApplicationUserMapping
 from prison.models import Prison
 from mtp_auth.tests.mommy_recipes import create_prison_user_mapping, \
     create_prisoner_location_admins, create_bank_admins, create_refund_bank_admins
@@ -23,14 +24,8 @@ def make_test_users(clerks_per_prison=2):
     # bank admin
     bank_admins = create_bank_admins()
     refund_bank_admins = create_refund_bank_admins()
-    return (prison_clerks, prisoner_location_admins, bank_admins, refund_bank_admins)
 
-
-def make_test_oauth_applications():
-    """
-    Creates test oauth clients with secret == client id
-    for test purposes.
-    """
+    # create test oauth applications
     user = User.objects.first()
 
     for client_id in [
@@ -46,3 +41,17 @@ def make_test_oauth_applications():
             name=client_id,
             user=user
         )
+
+    def link_users_with_client(users, client_id):
+        for user in users:
+            ApplicationUserMapping.objects.get_or_create(
+                user=user,
+                application=Application.objects.get(client_id=client_id)
+            )
+
+    link_users_with_client(prison_clerks, CASHBOOK_OAUTH_CLIENT_ID)
+    link_users_with_client(prisoner_location_admins, PRISONER_LOCATION_OAUTH_CLIENT_ID)
+    link_users_with_client(bank_admins, BANK_ADMIN_OAUTH_CLIENT_ID)
+    link_users_with_client(refund_bank_admins, BANK_ADMIN_OAUTH_CLIENT_ID)
+
+    return (prison_clerks, prisoner_location_admins, bank_admins, refund_bank_admins)

--- a/mtp_api/apps/mtp_auth/migrations/0003_applicationusermapping.py
+++ b/mtp_api/apps/mtp_auth/migrations/0003_applicationusermapping.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import model_utils.fields
+from django.conf import settings
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.OAUTH2_PROVIDER_APPLICATION_MODEL),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('mtp_auth', '0002_prisonusermapping_prisons'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ApplicationUserMapping',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
+                ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
+                ('application', models.ForeignKey(to=settings.OAUTH2_PROVIDER_APPLICATION_MODEL)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+    ]

--- a/mtp_api/apps/mtp_auth/models.py
+++ b/mtp_api/apps/mtp_auth/models.py
@@ -10,3 +10,9 @@ class PrisonUserMapping(TimeStampedModel):
 
     def __str__(self):
         return self.user.username
+
+
+class ApplicationUserMapping(TimeStampedModel):
+
+    user = models.ForeignKey('auth.User')
+    application = models.ForeignKey('oauth2_provider.Application')

--- a/mtp_api/apps/mtp_auth/validators.py
+++ b/mtp_api/apps/mtp_auth/validators.py
@@ -1,0 +1,16 @@
+from oauth2_provider.oauth2_validators import OAuth2Validator
+
+from .models import ApplicationUserMapping
+
+
+class ApplicationRequestValidator(OAuth2Validator):
+
+    def validate_user(self, username, password, client, request, *args, **kwargs):
+        valid = super(ApplicationRequestValidator, self).validate_user(
+            username, password, client, request, *args, **kwargs
+        )
+        if valid and ApplicationUserMapping.objects.filter(
+                user=request.user, application=client).exists():
+            return True
+        request.user = None
+        return False

--- a/mtp_api/apps/prison/tests/test_views.py
+++ b/mtp_api/apps/prison/tests/test_views.py
@@ -6,8 +6,7 @@ from django.core.urlresolvers import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from core.tests.utils import make_test_users, \
-    make_test_oauth_applications
+from core.tests.utils import make_test_users
 
 from mtp_auth.tests.utils import AuthTestCaseMixin
 from mtp_auth.constants import CASHBOOK_OAUTH_CLIENT_ID
@@ -24,7 +23,6 @@ class PrisonerLocationViewTestCase(AuthTestCaseMixin, APITestCase):
         super(PrisonerLocationViewTestCase, self).setUp()
         self.prison_clerks, self.users, self.bank_admins, _ = make_test_users()
         self.prisons = Prison.objects.all()
-        make_test_oauth_applications()
 
     @property
     def list_url(self):

--- a/mtp_api/apps/transaction/tests/test_base.py
+++ b/mtp_api/apps/transaction/tests/test_base.py
@@ -3,7 +3,7 @@ from oauth2_provider.models import AccessToken
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from core.tests.utils import make_test_users, make_test_oauth_applications
+from core.tests.utils import make_test_users
 from mtp_auth.tests.utils import AuthTestCaseMixin
 
 from prison.models import Prison
@@ -38,7 +38,6 @@ class BaseTransactionViewTestCase(AuthTestCaseMixin, APITestCase):
             transaction_batch=self.transaction_batch
         )
         self.prisons = Prison.objects.all()
-        make_test_oauth_applications()
 
     def _get_locked_transactions_qs(self, prisons, user=None):
         params = {

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -163,8 +163,10 @@ OAUTH2_PROVIDER = {
     'SCOPES': {
         'read': 'Read scope',
         'write': 'Write scope',
-    }
+    },
+    'OAUTH2_VALIDATOR_CLASS': 'mtp_auth.validators.ApplicationRequestValidator'
 }
+OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
 
 try:
     from .local import *


### PR DESCRIPTION
This means that only users which has been explicitly linked to
a particular application (e.g. bank admin, cashbook) can authenticate
with that client. This means that a prison clerk cannot log in to
bank admin (unless they have been allowed to).

Uses a new table mtp_auth_applicationusermapping to store the mapping
of users to applications which they can log in to.