### PR TITLE
Run a migrate task before attempting to flush when resetting db

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -3,9 +3,11 @@ set -e
 
 if [[ "${DOCKER_STATE}" == 'reset_db' ]]
 then
-	echo "flushing db"
-	python manage.py flush --noinput --settings=mtp_api.settings.prod
     echo "running migrate"
+    python manage.py migrate --settings=mtp_api.settings.prod
+    echo "flushing db"
+    python manage.py flush --noinput --settings=mtp_api.settings.prod
+    echo "running migrate (replacing fixtures)"
     python manage.py migrate --settings=mtp_api.settings.prod
     echo "loading test data"
     python manage.py load_test_data --settings=mtp_api.settings.prod


### PR DESCRIPTION
The flush command operates on an explicit list of table so if the
tables defined in the application is different to those present
in the db it will fail. For this reason a migrate must be run
before the flush command to ensure that the db data model matches
that of the application.