### PR TITLE
Add reconciliation tracking to transaction model

### DIFF
--- a/mtp_api/apps/transaction/api/bank_admin/serializers.py
+++ b/mtp_api/apps/transaction/api/bank_admin/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 from rest_framework.fields import IntegerField
 
 from transaction.signals import transaction_created, transaction_refunded, \
-    transaction_prisons_need_updating
+    transaction_prisons_need_updating, transaction_reconciled
 from transaction.models import Transaction
 from prison.serializers import PrisonSerializer
 
@@ -50,14 +50,24 @@ class CreateTransactionSerializer(serializers.ModelSerializer):
         )
 
 
-class UpdateRefundedTransactionListSerializer(serializers.ListSerializer):
+class UpdateTransactionListSerializer(serializers.ListSerializer):
 
     @transaction.atomic
     def update(self, instance, validated_data):
         user = self.context['request'].user
 
-        to_refund = [t['id'] for t in validated_data if t['refunded']]
+        to_refund = [t['id'] for t in validated_data if t.get('refunded', False)]
+        to_reconcile = [t['id'] for t in validated_data if t.get('reconciled', False)]
 
+        updated_transactions = []
+        if to_refund:
+            updated_transactions += self.refund(user, to_refund)
+        if to_reconcile:
+            updated_transactions += self.reconcile(user, to_reconcile)
+
+        return updated_transactions
+
+    def refund(self, user, to_refund):
         update_set = Transaction.objects.filter(
             pk__in=to_refund,
             **Transaction.STATUS_LOOKUP['refund_pending']).select_for_update()
@@ -79,16 +89,45 @@ class UpdateRefundedTransactionListSerializer(serializers.ListSerializer):
 
         return updated_transactions
 
+    def reconcile(self, user, to_reconcile):
+        update_set = Transaction.objects.filter(
+            pk__in=to_reconcile,
+            reconciled=False,
+            **Transaction.STATUS_LOOKUP['refunded']).select_for_update()
+        update_set = update_set | Transaction.objects.filter(
+            pk__in=to_reconcile,
+            reconciled=False,
+            **Transaction.STATUS_LOOKUP['credited']).select_for_update()
+
+        if len(update_set) != len(to_reconcile):
+            raise Transaction.DoesNotExist(
+                list(set(to_reconcile) - {t.id for t in update_set})
+            )
+
+        updated_transactions = list(update_set)
+        update_set.update(reconciled=True)
+
+        for transaction in updated_transactions:
+            transaction.reconciled = True
+            transaction_reconciled.send(
+                sender=Transaction,
+                transaction=transaction,
+                by_user=user
+            )
+
+        return updated_transactions
+
 
 class UpdateRefundedTransactionSerializer(serializers.ModelSerializer):
     id = IntegerField(read_only=False)
 
     class Meta:
         model = Transaction
-        list_serializer_class = UpdateRefundedTransactionListSerializer
+        list_serializer_class = UpdateTransactionListSerializer
         fields = (
             'id',
-            'refunded'
+            'refunded',
+            'reconciled'
         )
 
 

--- a/mtp_api/apps/transaction/constants.py
+++ b/mtp_api/apps/transaction/constants.py
@@ -30,4 +30,5 @@ LOG_ACTIONS = Choices(
     ('CREDITED', 'credited', 'Credited'),
     ('UNCREDITED', 'uncredited', 'Uncredited'),
     ('REFUNDED', 'refunded', 'Refunded'),
+    ('RECONCILED', 'reconciled', 'Reconciled')
 )

--- a/mtp_api/apps/transaction/managers.py
+++ b/mtp_api/apps/transaction/managers.py
@@ -73,3 +73,10 @@ class LogManager(models.Manager):
             action=LOG_ACTIONS.REFUNDED,
             user=by_user
         )
+
+    def transaction_reconciled(self, transaction, by_user):
+        self.create(
+            transaction=transaction,
+            action=LOG_ACTIONS.RECONCILED,
+            user=by_user
+        )

--- a/mtp_api/apps/transaction/migrations/0014_auto_20151013_1113.py
+++ b/mtp_api/apps/transaction/migrations/0014_auto_20151013_1113.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transaction', '0013_transaction_prisoner_name'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='transaction',
+            name='reconciled',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AlterField(
+            model_name='log',
+            name='action',
+            field=models.CharField(max_length=50, choices=[('created', 'Created'), ('locked', 'Locked'), ('unlocked', 'Unlocked'), ('credited', 'Credited'), ('uncredited', 'Uncredited'), ('refunded', 'Refunded'), ('reconciled', 'Reconciled')]),
+        ),
+    ]

--- a/mtp_api/apps/transaction/models.py
+++ b/mtp_api/apps/transaction/models.py
@@ -10,7 +10,7 @@ from .constants import TRANSACTION_STATUS, LOG_ACTIONS
 from .managers import TransactionQuerySet, LogManager
 from .signals import transaction_created, transaction_locked, \
     transaction_unlocked, transaction_credited, transaction_refunded, \
-    transaction_prisons_need_updating
+    transaction_prisons_need_updating, transaction_reconciled
 
 
 class Transaction(TimeStampedModel):
@@ -41,6 +41,9 @@ class Transaction(TimeStampedModel):
     credited = models.BooleanField(default=False)
 
     refunded = models.BooleanField(default=False)
+
+    # reconciled is orthogonal to status
+    reconciled = models.BooleanField(default=False)
 
     STATUS_LOOKUP = {
         TRANSACTION_STATUS.LOCKED:
@@ -137,6 +140,11 @@ def transaction_credited_receiver(sender, transaction, by_user, credited=True, *
 @receiver(transaction_refunded)
 def transaction_refunded_receiver(sender, transaction, by_user, **kwargs):
     Log.objects.transaction_refunded(transaction, by_user)
+
+
+@receiver(transaction_reconciled)
+def transaction_reconciled_receiver(sender, transaction, by_user, **kwargs):
+    Log.objects.transaction_reconciled(transaction, by_user)
 
 
 @receiver(transaction_prisons_need_updating)

--- a/mtp_api/apps/transaction/signals.py
+++ b/mtp_api/apps/transaction/signals.py
@@ -5,5 +5,6 @@ transaction_locked = Signal(providing_args=['transaction', 'by_user'])
 transaction_unlocked = Signal(providing_args=['transaction', 'by_user'])
 transaction_credited = Signal(providing_args=['transaction', 'by_user'])
 transaction_refunded = Signal(providing_args=['transaction', 'by_user'])
+transaction_reconciled = Signal(providing_args=['transaction', 'by_user'])
 
 transaction_prisons_need_updating = Signal()


### PR DESCRIPTION
This consists of a new field, reconciled, which is orthogonal to
the status of the transaction. It is now possible to filter by
this field when querying the bank_admin endpoint. A new Log record
is created whenever a transaction is reconciled, which is done
by a patch request to the bank_admin transaction endpoint.