### PR TITLE
Update permissions for bank admin updating transactions

### DIFF
--- a/mtp_api/apps/mtp_auth/fixtures/initial_groups.json
+++ b/mtp_api/apps/mtp_auth/fixtures/initial_groups.json
@@ -16,7 +16,8 @@
     "name": "BankAdmin",
     "permissions": [
       ["add_transaction", "transaction", "transaction"],
-      ["view_transaction", "transaction", "transaction"]
+      ["view_transaction", "transaction", "transaction"],
+      ["patch_processed_transaction", "transaction", "transaction"]
     ]
   }
 },
@@ -39,8 +40,7 @@
   "fields": {
     "name": "RefundBankAdmin",
     "permissions": [
-      ["view_bank_details_transaction", "transaction", "transaction"],
-      ["patch_refunded_transaction", "transaction", "transaction"]
+      ["view_bank_details_transaction", "transaction", "transaction"]
     ]
   }
 }

--- a/mtp_api/apps/transaction/api/bank_admin/permissions.py
+++ b/mtp_api/apps/transaction/api/bank_admin/permissions.py
@@ -5,5 +5,5 @@ class TransactionPermissions(ActionsBasedPermissions):
     actions_perms_map = ActionsBasedPermissions.actions_perms_map.copy()
     actions_perms_map.update({
         'list': ['%(app_label)s.view_%(model_name)s'],
-        'patch_refunded': ['%(app_label)s.patch_refunded_%(model_name)s']
+        'patch_processed': ['%(app_label)s.patch_processed_%(model_name)s']
     })

--- a/mtp_api/apps/transaction/api/bank_admin/urls.py
+++ b/mtp_api/apps/transaction/api/bank_admin/urls.py
@@ -6,6 +6,6 @@ urlpatterns = patterns('',
     url(r'^transactions/$', views.TransactionView.as_view({
         'get': 'list',
         'post': 'create',
-        'patch': 'patch_refunded'
+        'patch': 'patch_processed'
     }), name='transaction-list'),
 )

--- a/mtp_api/apps/transaction/api/bank_admin/views.py
+++ b/mtp_api/apps/transaction/api/bank_admin/views.py
@@ -48,7 +48,7 @@ class TransactionView(mixins.CreateModelMixin, mixins.UpdateModelMixin,
         TransactionPermissions
     )
 
-    def patch_refunded(self, request, *args, **kwargs):
+    def patch_processed(self, request, *args, **kwargs):
         try:
             return self.partial_update(request, *args, **kwargs)
         except Transaction.DoesNotExist as e:
@@ -56,7 +56,7 @@ class TransactionView(mixins.CreateModelMixin, mixins.UpdateModelMixin,
                 data={
                     'errors': [
                         {
-                            'msg': 'Some transactions could not be refunded',
+                            'msg': 'Some transactions could not be updated',
                             'ids': sorted(e.args[0])
                         }
                     ]

--- a/mtp_api/apps/transaction/migrations/0015_auto_20151019_1430.py
+++ b/mtp_api/apps/transaction/migrations/0015_auto_20151019_1430.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transaction', '0014_auto_20151013_1113'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='transaction',
+            options={'permissions': (('view_transaction', 'Can view transaction'), ('view_bank_details_transaction', 'Can view bank details of transaction'), ('lock_transaction', 'Can lock transaction'), ('unlock_transaction', 'Can unlock transaction'), ('patch_credited_transaction', 'Can patch credited transaction'), ('patch_processed_transaction', 'Can patch processed transaction')), 'ordering': ('received_at',)},
+        ),
+    ]

--- a/mtp_api/apps/transaction/models.py
+++ b/mtp_api/apps/transaction/models.py
@@ -93,7 +93,7 @@ class Transaction(TimeStampedModel):
             ("lock_transaction", "Can lock transaction"),
             ("unlock_transaction", "Can unlock transaction"),
             ("patch_credited_transaction", "Can patch credited transaction"),
-            ("patch_refunded_transaction", "Can patch refunded transaction"),
+            ("patch_processed_transaction", "Can patch processed transaction"),
         )
         index_together = [
             ["prisoner_number", "prisoner_dob"],

--- a/mtp_api/apps/transaction/tests/test_bank_admin_views.py
+++ b/mtp_api/apps/transaction/tests/test_bank_admin_views.py
@@ -155,7 +155,7 @@ class UpdateRefundTransactionsTestCase(
         ]
 
     def _get_unauthorised_user(self):
-        return self.bank_admins[0]
+        return self.prison_clerks[0]
 
     def _get_authorised_user(self):
         return self.refund_bank_admins[0]
@@ -292,10 +292,10 @@ class UpdateReconcileTransactionsTestCase(
         ]
 
     def _get_unauthorised_user(self):
-        return self.bank_admins[0]
+        return self.prison_clerks[0]
 
     def _get_authorised_user(self):
-        return self.refund_bank_admins[0]
+        return self.bank_admins[0]
 
     def _get_url(self, *args, **kwargs):
         return reverse('bank_admin:transaction-list')


### PR DESCRIPTION
This change allows all bank admins to make updates to transactions,
to allow for the need for non-refund bank admins to update transactions
that have been reconciled.