### PR TITLE
Add --noinput flag to setup management commands

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -4,17 +4,17 @@ set -e
 if [[ "${DOCKER_STATE}" == 'reset_db' ]]
 then
     echo "running migrate"
-    python manage.py migrate --settings=mtp_api.settings.prod
+    python manage.py migrate --settings=mtp_api.settings.prod --noinput
     echo "flushing db"
-    python manage.py flush --noinput --settings=mtp_api.settings.prod
+    python manage.py flush --noinput --settings=mtp_api.settings.prod --noinput
     echo "running migrate (replacing fixtures)"
-    python manage.py migrate --settings=mtp_api.settings.prod
+    python manage.py migrate --settings=mtp_api.settings.prod --noinput
     echo "loading test data"
     python manage.py load_test_data --settings=mtp_api.settings.prod
 elif [[ "${DOCKER_STATE}" == 'migrate' ]]
 then
     echo "running migrate"
-    python ./manage.py migrate --settings=mtp_api.settings.prod
+    python ./manage.py migrate --settings=mtp_api.settings.prod --noinput
 fi
 
 /usr/local/bin/uwsgi --ini /etc/uwsgi/magiclantern.ini


### PR DESCRIPTION
As these are run by a script, cannot rely on user input.
Will rely on humans to clean up any issues.