### PR TITLE
Increase the max length of the label field on batch records

### DIFF
--- a/mtp_api/apps/account/migrations/0004_auto_20151110_1038.py
+++ b/mtp_api/apps/account/migrations/0004_auto_20151110_1038.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('account', '0003_manual_20151106'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='batch',
+            name='label',
+            field=models.CharField(max_length=30, db_index=True),
+        ),
+    ]

--- a/mtp_api/apps/account/models.py
+++ b/mtp_api/apps/account/models.py
@@ -5,7 +5,7 @@ from transaction.models import Transaction
 
 
 class Batch(TimeStampedModel):
-    label = models.CharField(max_length=15, db_index=True)
+    label = models.CharField(max_length=30, db_index=True)
     transactions = models.ManyToManyField(Transaction)
 
     def __str__(self):


### PR DESCRIPTION
Although we do want to enforce shorter labels, the previous
length was overly restrictive.