### PR TITLE
Prevent brute force login attacks by locking user accounts

### DIFF
--- a/mtp_api/apps/mtp_auth/migrations/0004_failedloginattempt.py
+++ b/mtp_api/apps/mtp_auth/migrations/0004_failedloginattempt.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import django.utils.timezone
+import model_utils.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.OAUTH2_PROVIDER_APPLICATION_MODEL),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('mtp_auth', '0003_applicationusermapping'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='FailedLoginAttempt',
+            fields=[
+                ('id', models.AutoField(primary_key=True, verbose_name='ID', serialize=False, auto_created=True)),
+                ('created', model_utils.fields.AutoCreatedField(verbose_name='created', editable=False, default=django.utils.timezone.now)),
+                ('modified', model_utils.fields.AutoLastModifiedField(verbose_name='modified', editable=False, default=django.utils.timezone.now)),
+                ('application', models.ForeignKey(to=settings.OAUTH2_PROVIDER_APPLICATION_MODEL)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'abstract': False,
+                'ordering': ('-created',)
+            },
+        ),
+    ]

--- a/mtp_api/apps/mtp_auth/models.py
+++ b/mtp_api/apps/mtp_auth/models.py
@@ -1,5 +1,8 @@
-from django.db import models
+import datetime
 
+from django.conf import settings
+from django.db import models
+from django.utils.timezone import now
 from model_utils.models import TimeStampedModel
 
 
@@ -16,6 +19,47 @@ class ApplicationUserMapping(TimeStampedModel):
 
     user = models.ForeignKey('auth.User')
     application = models.ForeignKey('oauth2_provider.Application')
+
+    def __str__(self):
+        return self.user.username
+
+
+class FailedLoginAttemptManager(models.Manager):
+    def is_locked_out(self, user, client):
+        failed_attempts = self.get_queryset().filter(
+            user=user,
+            application=client,
+        )
+        failed_attempt_count = failed_attempts.count()
+        if not failed_attempt_count:
+            return False
+
+        last_failed_attempt = failed_attempts.first()
+        lockout_period = datetime.timedelta(seconds=settings.MTP_AUTH_LOCKOUT_LOCKOUT_PERIOD)
+        return failed_attempt_count >= settings.MTP_AUTH_LOCKOUT_COUNT and \
+            last_failed_attempt.created > now() - lockout_period
+
+    def delete_failed_attempts(self, user, client):
+        self.get_queryset().filter(
+            user=user,
+            application=client,
+        ).delete()
+
+    def add_failed_attempt(self, user, client):
+        self.get_queryset().create(
+            user=user,
+            application=client,
+        )
+
+
+class FailedLoginAttempt(TimeStampedModel):
+    user = models.ForeignKey('auth.User')
+    application = models.ForeignKey('oauth2_provider.Application')
+
+    objects = FailedLoginAttemptManager()
+
+    class Meta:
+        ordering = ('-created',)
 
     def __str__(self):
         return self.user.username

--- a/mtp_api/apps/mtp_auth/validators.py
+++ b/mtp_api/apps/mtp_auth/validators.py
@@ -1,16 +1,31 @@
+from django.contrib.auth import get_user_model
 from oauth2_provider.oauth2_validators import OAuth2Validator
 
-from .models import ApplicationUserMapping
+from .models import ApplicationUserMapping, FailedLoginAttempt
+
+
+class LockedOut(Exception):
+    pass
 
 
 class ApplicationRequestValidator(OAuth2Validator):
-
     def validate_user(self, username, password, client, request, *args, **kwargs):
-        valid = super(ApplicationRequestValidator, self).validate_user(
-            username, password, client, request, *args, **kwargs
-        )
-        if valid and ApplicationUserMapping.objects.filter(
-                user=request.user, application=client).exists():
-            return True
+        user = get_user_model().objects.filter(username=username).first()
+        try:
+            if user and FailedLoginAttempt.objects.is_locked_out(user, client):
+                raise LockedOut
+
+            valid = super().validate_user(
+                username, password, client, request, *args, **kwargs
+            )
+            if valid and ApplicationUserMapping.objects.filter(
+                    user=request.user, application=client).exists():
+                FailedLoginAttempt.objects.delete_failed_attempts(user, client)
+                return True
+            elif user:
+                FailedLoginAttempt.objects.add_failed_attempt(user, client)
+        except LockedOut:
+            pass
+
         request.user = None
         return False

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -179,6 +179,8 @@ OAUTH2_PROVIDER = {
     'OAUTH2_VALIDATOR_CLASS': 'mtp_auth.validators.ApplicationRequestValidator'
 }
 OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
+MTP_AUTH_LOCKOUT_COUNT = 5  # 5 times
+MTP_AUTH_LOCKOUT_LOCKOUT_PERIOD = 30 * 60  # 30 minutes
 
 try:
     from .local import *


### PR DESCRIPTION
for half an hour if there are 5 failed attempts ever