### PR TITLE
Track reconciliation

### DIFF
--- a/mtp_api/apps/transaction/api/bank_admin/urls.py
+++ b/mtp_api/apps/transaction/api/bank_admin/urls.py
@@ -7,5 +7,7 @@ urlpatterns = [
         'get': 'list',
         'post': 'create',
         'patch': 'patch_processed'
-    }), name='transaction-list'),
+        }), name='transaction-list'),
+    url(r'^transactions/reconcile/$', views.ReconcileTransactionsView.as_view(),
+        name='reconcile-transactions')
 ]

--- a/mtp_api/apps/transaction/constants.py
+++ b/mtp_api/apps/transaction/constants.py
@@ -30,4 +30,5 @@ LOG_ACTIONS = Choices(
     ('CREDITED', 'credited', 'Credited'),
     ('UNCREDITED', 'uncredited', 'Uncredited'),
     ('REFUNDED', 'refunded', 'Refunded'),
+    ('RECONCILED', 'reconciled', 'Reconciled'),
 )

--- a/mtp_api/apps/transaction/managers.py
+++ b/mtp_api/apps/transaction/managers.py
@@ -32,7 +32,7 @@ class TransactionQuerySet(models.QuerySet):
             "FROM transaction_transaction AS t LEFT OUTER JOIN prison_prisonerlocation AS pl "
             "ON t.prisoner_number = pl.prisoner_number AND t.prisoner_dob = pl.prisoner_dob "
             "WHERE t.owner_id IS NULL AND t.credited is False AND t.refunded is False "
-            "AND transaction_transaction.id = t.id "
+            "AND t.reconciled is False AND transaction_transaction.id = t.id "
         )
 
 

--- a/mtp_api/apps/transaction/managers.py
+++ b/mtp_api/apps/transaction/managers.py
@@ -73,3 +73,10 @@ class LogManager(models.Manager):
             action=LOG_ACTIONS.REFUNDED,
             user=by_user
         )
+
+    def transaction_reconciled(self, transaction, by_user):
+        self.create(
+            transaction=transaction,
+            action=LOG_ACTIONS.RECONCILED,
+            user=by_user
+        )

--- a/mtp_api/apps/transaction/migrations/0017_auto_20151125_1040.py
+++ b/mtp_api/apps/transaction/migrations/0017_auto_20151125_1040.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('transaction', '0016_auto_20151103_1154'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='transaction',
+            name='reconciled',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AlterField(
+            model_name='log',
+            name='action',
+            field=models.CharField(max_length=50, choices=[('created', 'Created'), ('locked', 'Locked'), ('unlocked', 'Unlocked'), ('credited', 'Credited'), ('uncredited', 'Uncredited'), ('refunded', 'Refunded'), ('reconciled', 'Reconciled')]),
+        ),
+    ]

--- a/mtp_api/apps/transaction/models.py
+++ b/mtp_api/apps/transaction/models.py
@@ -10,7 +10,7 @@ from .constants import TRANSACTION_STATUS, LOG_ACTIONS
 from .managers import TransactionQuerySet, LogManager
 from .signals import transaction_created, transaction_locked, \
     transaction_unlocked, transaction_credited, transaction_refunded, \
-    transaction_prisons_need_updating
+    transaction_prisons_need_updating, transaction_reconciled
 
 
 class Transaction(TimeStampedModel):
@@ -41,6 +41,8 @@ class Transaction(TimeStampedModel):
     credited = models.BooleanField(default=False)
 
     refunded = models.BooleanField(default=False)
+
+    reconciled = models.BooleanField(default=False)
 
     STATUS_LOOKUP = {
         TRANSACTION_STATUS.LOCKED:
@@ -165,6 +167,11 @@ def transaction_credited_receiver(sender, transaction, by_user, credited=True, *
 @receiver(transaction_refunded)
 def transaction_refunded_receiver(sender, transaction, by_user, **kwargs):
     Log.objects.transaction_refunded(transaction, by_user)
+
+
+@receiver(transaction_reconciled)
+def transaction_reconciled_receiver(sender, transaction, by_user, **kwargs):
+    Log.objects.transaction_reconciled(transaction, by_user)
 
 
 @receiver(transaction_prisons_need_updating)

--- a/mtp_api/apps/transaction/signals.py
+++ b/mtp_api/apps/transaction/signals.py
@@ -5,5 +5,6 @@ transaction_locked = Signal(providing_args=['transaction', 'by_user'])
 transaction_unlocked = Signal(providing_args=['transaction', 'by_user'])
 transaction_credited = Signal(providing_args=['transaction', 'by_user'])
 transaction_refunded = Signal(providing_args=['transaction', 'by_user'])
+transaction_reconciled = Signal(providing_args=['transaction', 'by_user'])
 
 transaction_prisons_need_updating = Signal()


### PR DESCRIPTION
The purpose is that after a reconciliation file for a particular day has been downloaded,
all transactions for that day should be marked as reconciled and no longer be updated
by subsequent uploads of the prisoner location file.