### PR TITLE
Enable test data reset tools prevent deletion of specified users

### DIFF
--- a/mtp_api/apps/core/management/commands/delete_all_data.py
+++ b/mtp_api/apps/core/management/commands/delete_all_data.py
@@ -18,7 +18,9 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('--protect-users', default='none',
                             choices=['all', 'superusers', 'none'],
-                            help='Prevents users from being deleted')
+                            help='Prevents user types from being deleted')
+        parser.add_argument('--protect-usernames', nargs='*',
+                            help='Prevents specific usernames being deleted')
         parser.add_argument('--protect-prisons', action='store_true',
                             help='Prevents prisons from being deleted')
         parser.add_argument('--protect-prisoner-locations', action='store_true',
@@ -32,6 +34,7 @@ class Command(BaseCommand):
 
         verbosity = options['verbosity']
         protect_users = options['protect_users']
+        protect_usernames = options['protect_usernames']
         protect_prisons = options['protect_prisons']
         protect_prisoner_locations = options['protect_prisoner_locations']
         protect_transactions = options['protect_transactions']
@@ -48,7 +51,7 @@ class Command(BaseCommand):
             PrisonerLocation.objects.all().delete()
 
         if protect_users != 'all':
-            user_set = get_user_model().objects.all()
+            user_set = get_user_model().objects.exclude(username__in=protect_usernames or [])
             if protect_users == 'superusers':
                 user_set = user_set.exclude(is_superuser=True)
             print_message('Deleting %d users' % user_set.count())

--- a/mtp_api/apps/core/management/commands/load_test_data.py
+++ b/mtp_api/apps/core/management/commands/load_test_data.py
@@ -21,6 +21,8 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('--protect-superusers', action='store_true',
                             help='Prevents superusers from being deleted')
+        parser.add_argument('--protect-usernames', nargs='*',
+                            help='Prevents specific usernames being deleted')
         parser.add_argument('--protect-transactions', action='store_true',
                             help='Prevents existing transactions from being deleted')
         parser.add_argument('--prisons', nargs='*', default=['sample'],
@@ -38,6 +40,7 @@ class Command(BaseCommand):
 
         verbosity = options.get('verbosity', 1)
         protect_superusers = options['protect_superusers']
+        protect_usernames = options['protect_usernames']
         protect_transactions = options['protect_transactions']
         prisons = options['prisons']
         clerks_per_prison = options['clerks_per_prison']
@@ -50,7 +53,7 @@ class Command(BaseCommand):
             Batch.objects.all().delete()
             Transaction.objects.all().delete()
 
-        user_set = get_user_model().objects.all()
+        user_set = get_user_model().objects.exclude(username__in=protect_usernames or [])
         if protect_superusers:
             user_set = user_set.exclude(is_superuser=True)
         print_message('Deleting %d users' % user_set.count())

--- a/mtp_api/apps/core/tests/test_admin.py
+++ b/mtp_api/apps/core/tests/test_admin.py
@@ -57,6 +57,8 @@ class RecreateTestDataViewTestCase(TestCase):
             self.assertEqual(method.call_count, 1)
             expected_options_subset = {
                 'protect_superusers': True,
+                'protect_usernames': ['transaction-uploader'],
+                'protect_transactions': False,
                 'no_color': True,
                 'transactions': 'random',
                 'prisons': ['sample'],

--- a/mtp_api/apps/core/views.py
+++ b/mtp_api/apps/core/views.py
@@ -49,6 +49,7 @@ class RecreateTestDataView(FormView):
         if scenario in ('random', 'cashbook'):
             options.update({
                 'protect_superusers': True,
+                'protect_usernames': ['transaction-uploader'],
                 'protect_transactions': False,
                 'clerks_per_prison': 4,
             })


### PR DESCRIPTION
mainly to ensure transaction-uploader always has a user account that won't get deleted even in non-prod environments