### PR TITLE
Add a healthcheck.json view for IRaT support which tests database connectivity

### DIFF
--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -56,6 +56,8 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
 )
 
+HEALTHCHECKS = ['moj_irat.healthchecks.database_healthcheck']
+AUTODISCOVER_HEALTHCHECKS = False
 
 # security tightening
 # some overridden in prod/docker settings where SSL is ensured

--- a/mtp_api/urls.py
+++ b/mtp_api/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import include, url
 from django.contrib import admin
 
-from moj_utils.views import PingJsonView
+from moj_irat.views import HealthcheckView, PingJsonView
 
 admin.site.index_template = 'core/index.html'
 
@@ -21,4 +21,5 @@ urlpatterns = [
         commit_id_key='APP_GIT_COMMIT',
         version_number_key='APP_BUILD_TAG',
     ), name='ping_json'),
+    url(r'^healthcheck.json$', HealthcheckView.as_view(), name='healthcheck_json'),
 ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,3 +11,4 @@ fake-factory>=0.5,<0.6
 model-mommy==1.2.4
 pytz>=2015.7
 git+git://github.com/ministryofjustice/django-utils.git
+git+git://github.com/ministryofjustice/django-moj-irat.git


### PR DESCRIPTION
depends on [django-moj-irat#1](https://github.com/ministryofjustice/django-moj-irat/pull/1)