### PR TITLE
Collect static files as well as updating python requirements earlier in build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update && \
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 WORKDIR /app
-RUN mkdir -p /app
+RUN mkdir -p /app/mtp_api/assets
+RUN mkdir -p /app/static
 
 RUN pip3 install -U setuptools pip wheel virtualenv
 RUN virtualenv -p python3.4 venv
@@ -24,7 +25,7 @@ ADD ./requirements /app/requirements
 RUN venv/bin/pip install -r requirements/docker.txt
 
 ADD . /app
-RUN make update python_requirements=requirements/docker.txt
+RUN make build python_requirements=requirements/docker.txt
 
 EXPOSE 8080
 CMD make uwsgi python_requirements=requirements/docker.txt

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,10 @@ update: venv/bin/pip
 	@venv/bin/pip install -U setuptools pip wheel ipython ipdb >$(TASK_OUTPUT_REDIRECTION)
 	@venv/bin/pip install -r $(python_requirements) >$(TASK_OUTPUT_REDIRECTION)
 
+# update environment and collect static files
+.PHONY: build
+build: update static_assets
+
 ##########################
 #### INTERNAL RECIPES ####
 ##########################


### PR DESCRIPTION
because Jenkins job wants these to exist before deployment so it can put them on S3
(aside: no clear idea why we use S3 to store assets as nginx proxies them back)