### PR TITLE
Improve test data

### DIFF
--- a/mtp_api/apps/core/management/commands/load_test_data.py
+++ b/mtp_api/apps/core/management/commands/load_test_data.py
@@ -90,6 +90,10 @@ class Command(BaseCommand):
                 use_test_nomis_prisoners=True,
                 predetermined_transactions=True,
                 only_new_transactions=True,
+                consistent_history=True,
+                include_debits=False,
+                include_administrative_credits=False,
+                include_online_payments=False
             )
 
     def handle_prod(self, **options):

--- a/mtp_api/apps/transaction/admin.py
+++ b/mtp_api/apps/transaction/admin.py
@@ -28,10 +28,16 @@ class TransactionAdmin(admin.ModelAdmin):
     ordering = ('-received_at',)
     readonly_fields = ('credited', 'refunded', 'reconciled')
     inlines = (LogAdminInline,)
-    list_filter = ('credited', 'refunded', 'reconciled',
-                   ('prison', RelatedAnyFieldListFilter),
-                   ('received_at', DateRangeFilter),
-                   ('owner__username', ExactSearchFilter))
+    list_filter = (
+        'credited',
+        'refunded',
+        'reconciled',
+        ('prison', RelatedAnyFieldListFilter),
+        'category',
+        'source',
+        ('received_at', DateRangeFilter),
+        ('owner__username', ExactSearchFilter)
+    )
     actions = [
         'display_total_amount', 'display_reference_validity',
         'display_resolution_time'

--- a/mtp_api/apps/transaction/tests/test_bank_admin_views.py
+++ b/mtp_api/apps/transaction/tests/test_bank_admin_views.py
@@ -1,4 +1,4 @@
-from datetime import datetime, date, timedelta, time
+from datetime import datetime, timedelta, time
 from unittest import mock
 
 from django.utils import timezone
@@ -658,8 +658,8 @@ class GetTransactionsFilteredByDateTestCase(GetTransactionsBaseTestCase):
         user = self._get_authorised_user()
 
         response = self.client.get(
-            url, {'received_at__lt': date.today(),
-                  'received_at__gte': date.today() - timedelta(days=2),
+            url, {'received_at__lt': self._get_latest_date(),
+                  'received_at__gte': self._get_latest_date() - timedelta(days=2),
                   'limit': 1000}, format='json',
             HTTP_AUTHORIZATION=self.get_http_authorization_for_user(user)
         )
@@ -667,11 +667,11 @@ class GetTransactionsFilteredByDateTestCase(GetTransactionsBaseTestCase):
 
         results = response.data['results']
         result_ids = [t['id'] for t in results]
-        today = datetime.combine(date.today(), time.min).replace(
+        yesterday = datetime.combine(self._get_latest_date(), time.min).replace(
             tzinfo=timezone.get_current_timezone())
         received_between_dates = Transaction.objects.filter(
-            received_at__lt=today,
-            received_at__gte=(today - timedelta(days=2))
+            received_at__lt=yesterday,
+            received_at__gte=(yesterday - timedelta(days=2))
         )
         self.assertEquals(len(result_ids), len(received_between_dates))
 
@@ -732,19 +732,19 @@ class ReconcileTransactionsTestCase(
         user = self._get_authorised_user()
 
         response = self.client.post(
-            url, {'date': date.today().isoformat()}, format='json',
+            url, {'date': self._get_latest_date().isoformat()}, format='json',
             HTTP_AUTHORIZATION=self.get_http_authorization_for_user(user)
         )
         self.assertEqual(response.status_code, http_status.HTTP_204_NO_CONTENT)
 
-        today = datetime.combine(date.today(), time.min).replace(
+        yesterday = datetime.combine(self._get_latest_date(), time.min).replace(
             tzinfo=timezone.get_current_timezone())
-        transactions_today = Transaction.objects.filter(
-            received_at__lt=today + timedelta(days=1),
-            received_at__gte=today
+        transactions_yesterday = Transaction.objects.filter(
+            received_at__lt=yesterday + timedelta(days=1),
+            received_at__gte=yesterday
         )
 
-        for transaction in transactions_today:
+        for transaction in transactions_yesterday:
             self.assertTrue(transaction.reconciled)
 
     def test_no_date_returns_bad_request(self):

--- a/mtp_api/apps/transaction/tests/test_base.py
+++ b/mtp_api/apps/transaction/tests/test_base.py
@@ -11,7 +11,7 @@ from prison.models import Prison
 from transaction.models import Transaction
 from transaction.constants import TRANSACTION_STATUS
 
-from .utils import generate_transactions
+from .utils import generate_transactions, latest_transaction_date
 
 
 class BaseTransactionViewTestCase(AuthTestCaseMixin, APITestCase):
@@ -35,6 +35,7 @@ class BaseTransactionViewTestCase(AuthTestCaseMixin, APITestCase):
             self.send_money_users,
         ) = make_test_users(clerks_per_prison=2)
 
+        self.latest_transaction_date = latest_transaction_date()
         self.transactions = generate_transactions(
             transaction_batch=self.transaction_batch
         )
@@ -61,6 +62,9 @@ class BaseTransactionViewTestCase(AuthTestCaseMixin, APITestCase):
         return Transaction.objects.filter(
             owner=user, credited=True, prison__in=prisons
         )
+
+    def _get_latest_date(self):
+        return self.latest_transaction_date.date()
 
 
 class TransactionRejectsRequestsWithoutPermissionTestMixin(object):

--- a/mtp_api/apps/transaction/tests/test_cashbook_views.py
+++ b/mtp_api/apps/transaction/tests/test_cashbook_views.py
@@ -336,21 +336,21 @@ class TransactionListWithReceivedAtFilterTestCase(TransactionListTestCase):
     def _format_date(self, date):
         return format_date(date, 'Y-m-d')
 
-    def test_filter_received_at_today(self):
+    def test_filter_received_at_yesterday(self):
         """
-        Returns all transactions received today
+        Returns all transactions received yesterday
         """
-        today = timezone.now().date()
+        yesterday = self._get_latest_date()
         self._test_response_with_filters(filters={
-            'received_at_0': self._format_date(today),
-            'received_at_1': self._format_date(today),
+            'received_at_0': self._format_date(yesterday),
+            'received_at_1': self._format_date(yesterday),
         })
 
     def test_filter_received_since_five_days_ago(self):
         """
         Returns all transactions received since 5 days ago
         """
-        five_days_ago = timezone.now().date() - datetime.timedelta(days=5)
+        five_days_ago = self._get_latest_date() - datetime.timedelta(days=5)
         self._test_response_with_filters(filters={
             'received_at_0': self._format_date(five_days_ago),
         })
@@ -359,7 +359,7 @@ class TransactionListWithReceivedAtFilterTestCase(TransactionListTestCase):
         """
         Returns all transactions received until 5 days ago
         """
-        five_days_ago = timezone.now().date() - datetime.timedelta(days=5)
+        five_days_ago = self._get_latest_date() - datetime.timedelta(days=5)
         self._test_response_with_filters(filters={
             'received_at_1': self._format_date(five_days_ago),
         })


### PR DESCRIPTION
For certain forms of testing, it is better that the test data
not cover all possible scenarios, but instead cover the business
as usual scenario. This means that test data should be historically
consistent i.e. all transactions processed up to the last weekday,
no old transactions that are further processed than newer ones etc.
This will also exclude administrative transactions and online
payment transactions.