### PR TITLE
Use UTC when manually parsing dates, to match TZ used by default

### DIFF
--- a/mtp_api/apps/transaction/api/bank_admin/views.py
+++ b/mtp_api/apps/transaction/api/bank_admin/views.py
@@ -124,7 +124,7 @@ class ReconcileTransactionsView(generics.GenericAPIView):
 
         try:
             parsed_date = datetime.strptime(date, '%Y-%m-%d').replace(
-                tzinfo=timezone.get_current_timezone())
+                tzinfo=timezone.utc)
         except ValueError:
             return Response(data={'errors': _("Invalid date format")},
                             status=400)

--- a/mtp_api/apps/transaction/tests/test_bank_admin_views.py
+++ b/mtp_api/apps/transaction/tests/test_bank_admin_views.py
@@ -671,7 +671,7 @@ class GetTransactionsFilteredByDateTestCase(GetTransactionsBaseTestCase):
         results = response.data['results']
         result_ids = [t['id'] for t in results]
         yesterday = datetime.combine(self._get_latest_date(), time.min).replace(
-            tzinfo=timezone.get_current_timezone())
+            tzinfo=timezone.utc)
         received_between_dates = Transaction.objects.filter(
             received_at__lt=yesterday,
             received_at__gte=(yesterday - timedelta(days=2))
@@ -741,7 +741,7 @@ class ReconcileTransactionsTestCase(
         self.assertEqual(response.status_code, http_status.HTTP_204_NO_CONTENT)
 
         yesterday = datetime.combine(self._get_latest_date(), time.min).replace(
-            tzinfo=timezone.get_current_timezone())
+            tzinfo=timezone.utc)
         transactions_yesterday = Transaction.objects.filter(
             received_at__lt=yesterday + timedelta(days=1),
             received_at__gte=yesterday

--- a/mtp_api/apps/transaction/tests/test_cashbook_views.py
+++ b/mtp_api/apps/transaction/tests/test_cashbook_views.py
@@ -106,7 +106,7 @@ class TransactionListTestCase(
             for date_format in settings.DATE_INPUT_FORMATS:
                 try:
                     date = datetime.datetime.strptime(date, date_format)
-                    return date.replace(tzinfo=timezone.get_current_timezone())
+                    return date.replace(tzinfo=timezone.utc)
                 except (ValueError, TypeError):
                     continue
             raise ValueError('Cannot parse date %s' % date)
@@ -116,11 +116,11 @@ class TransactionListTestCase(
         received_at_1 = (parse_date(received_at_1) + datetime.timedelta(days=1)) if received_at_1 else None
 
         if received_at_0 and received_at_1:
-            return lambda t: received_at_0 <= t.received_at < received_at_1
+            return lambda t: received_at_0 <= t.received_at <= received_at_1
         elif received_at_0:
             return lambda t: received_at_0 <= t.received_at
         elif received_at_1:
-            return lambda t: t.received_at < received_at_1
+            return lambda t: t.received_at <= received_at_1
         return noop_checker
 
     def _get_search_checker(self, filters, noop_checker):

--- a/mtp_api/apps/transaction/tests/utils.py
+++ b/mtp_api/apps/transaction/tests/utils.py
@@ -74,10 +74,7 @@ def generate_initial_transactions_data(
         random_date = latest_transaction_date() - datetime.timedelta(
             minutes=random.randint(0, 10000)
         )
-        midnight_random_date = datetime.datetime.combine(
-            random_date.date(), datetime.time.min
-        ).replace(tzinfo=timezone.get_current_timezone())
-
+        midnight_random_date = random_date.replace(hour=0, minute=0, second=0)
         data = {
             'category': TRANSACTION_CATEGORY.CREDIT,
             'amount': random.randint(1000, 30000),
@@ -153,7 +150,7 @@ def generate_predetermined_transactions_data():
     over_a_week_ago = now - datetime.timedelta(days=8)
     a_week_ago = over_a_week_ago + datetime.timedelta(days=1)
     data = {
-        'received_at': over_a_week_ago,
+        'received_at': over_a_week_ago.replace(hour=0, minute=0, second=0),
         'created': over_a_week_ago,
         'modified': a_week_ago,
         'owner': None,


### PR DESCRIPTION
Transactions in the DB are stored with a recevied_at date with a UTC
timezone, and date params parsed by django-reset-framework are similarly
given a UTC param. In places where this parsing is done in our code,
we have been using the current timezone instead, leading to inconcistencies
and incorrect behaviour. This fixes any manual parsing of a pure date into
a datetime to use the UTC timezone.