### PR TITLE
Allow for creation of variable number of test transactions

### DIFF
--- a/mtp_api/apps/core/forms.py
+++ b/mtp_api/apps/core/forms.py
@@ -11,6 +11,7 @@ class RecreateTestDataForm(forms.Form):
             ('delete-locations-transactions', _('Delete prisoner location and transaction data')),
         ),
     )
+    number_of_transactions = forms.IntegerField(initial=100)
 
 
 class AdminFilterForm(forms.Form):

--- a/mtp_api/apps/core/management/commands/load_test_data.py
+++ b/mtp_api/apps/core/management/commands/load_test_data.py
@@ -34,6 +34,8 @@ class Command(BaseCommand):
         parser.add_argument('--transactions', default='random',
                             choices=['none', 'random', 'nomis'],
                             help='Create new transactions using this method')
+        parser.add_argument('--number-of-transactions', default=100, type=int,
+                            help='Number of new transactions to create')
 
     def handle(self, *args, **options):
         if settings.ENVIRONMENT == 'prod':
@@ -78,16 +80,17 @@ class Command(BaseCommand):
         print_message('Making test users')
         make_test_users(clerks_per_prison=clerks_per_prison)
 
+        number_of_transactions = options['number_of_transactions']
         if transactions == 'random':
             print_message('Generating pre-defined prisoner locations')
             # to allow for automated testing
             generate_predefined_prisoner_locations()
             print_message('Generating random prisoner locations and transactions')
-            generate_transactions(transaction_batch=100)
+            generate_transactions(transaction_batch=number_of_transactions)
         elif transactions == 'nomis':
             print_message('Generating test NOMIS prisoner locations and transactions')
             generate_transactions(
-                transaction_batch=100,
+                transaction_batch=number_of_transactions,
                 use_test_nomis_prisoners=True,
                 predetermined_transactions=True,
                 only_new_transactions=True,

--- a/mtp_api/apps/core/tests/test_admin.py
+++ b/mtp_api/apps/core/tests/test_admin.py
@@ -52,6 +52,7 @@ class RecreateTestDataViewTestCase(TestCase):
         with mock.patch.object(Command, 'handle') as method:
             response = self.client.post(self.url, data={
                 'scenario': 'random',
+                'number_of_transactions': '100'
             })
             self.assertEqual(response.status_code, 200)
             self.assertEqual(method.call_count, 1)
@@ -62,6 +63,7 @@ class RecreateTestDataViewTestCase(TestCase):
                 'no_color': True,
                 'transactions': 'random',
                 'prisons': ['sample'],
+                'number_of_transactions': 100
             }
             options = method.call_args[1]
             options_subset = {

--- a/mtp_api/apps/core/views.py
+++ b/mtp_api/apps/core/views.py
@@ -47,6 +47,7 @@ class RecreateTestDataView(FormView):
             'no_color': True,
             'stdout': output,
             'stderr': output,
+            'number_of_transactions': form.cleaned_data['number_of_transactions']
         }
 
         if scenario in ('random', 'cashbook'):


### PR DESCRIPTION
When creating test transactions via management command or admin
interface, it should be possible to specify the number of transactions
that will be created.