### PR TITLE
Ensure consistent use of configured timezone

### DIFF
--- a/mtp_api/apps/transaction/api/bank_admin/views.py
+++ b/mtp_api/apps/transaction/api/bank_admin/views.py
@@ -123,8 +123,7 @@ class ReconcileTransactionsView(generics.GenericAPIView):
                             status=400)
 
         try:
-            parsed_date = datetime.strptime(date, '%Y-%m-%d').replace(
-                tzinfo=timezone.utc)
+            parsed_date = timezone.make_aware(datetime.strptime(date, '%Y-%m-%d'))
         except ValueError:
             return Response(data={'errors': _("Invalid date format")},
                             status=400)

--- a/mtp_api/apps/transaction/tests/test_bank_admin_views.py
+++ b/mtp_api/apps/transaction/tests/test_bank_admin_views.py
@@ -670,8 +670,7 @@ class GetTransactionsFilteredByDateTestCase(GetTransactionsBaseTestCase):
 
         results = response.data['results']
         result_ids = [t['id'] for t in results]
-        yesterday = datetime.combine(self._get_latest_date(), time.min).replace(
-            tzinfo=timezone.utc)
+        yesterday = timezone.make_aware(datetime.combine(self._get_latest_date(), time.min))
         received_between_dates = Transaction.objects.filter(
             received_at__lt=yesterday,
             received_at__gte=(yesterday - timedelta(days=2))
@@ -740,8 +739,7 @@ class ReconcileTransactionsTestCase(
         )
         self.assertEqual(response.status_code, http_status.HTTP_204_NO_CONTENT)
 
-        yesterday = datetime.combine(self._get_latest_date(), time.min).replace(
-            tzinfo=timezone.utc)
+        yesterday = timezone.make_aware(datetime.combine(self._get_latest_date(), time.min))
         transactions_yesterday = Transaction.objects.filter(
             received_at__lt=yesterday + timedelta(days=1),
             received_at__gte=yesterday

--- a/mtp_api/apps/transaction/tests/test_cashbook_views.py
+++ b/mtp_api/apps/transaction/tests/test_cashbook_views.py
@@ -106,7 +106,7 @@ class TransactionListTestCase(
             for date_format in settings.DATE_INPUT_FORMATS:
                 try:
                     date = datetime.datetime.strptime(date, date_format)
-                    return date.replace(tzinfo=timezone.utc)
+                    return timezone.make_aware(date)
                 except (ValueError, TypeError):
                     continue
             raise ValueError('Cannot parse date %s' % date)

--- a/mtp_api/apps/transaction/tests/utils.py
+++ b/mtp_api/apps/transaction/tests/utils.py
@@ -38,7 +38,9 @@ def random_reference(prisoner_number=None, prisoner_dob=None):
 
 
 def latest_transaction_date():
-    latest_transaction_date = timezone.now().replace(microsecond=0) - datetime.timedelta(days=1)
+    latest_transaction_date = timezone.make_aware(
+        datetime.datetime.now().replace(microsecond=0) - datetime.timedelta(days=1)
+    )
     while latest_transaction_date.weekday() > 4:
         latest_transaction_date = latest_transaction_date - datetime.timedelta(days=1)
     return latest_transaction_date


### PR DESCRIPTION
Use the default timezone where datetimes are parsed explicitly,
to match that employed by library methods and functions.

This is just to make sure that times are treated consistently, in
advance of discussing how to treat times.