### PR TITLE
Prevent reconciliation events being logged multiple times

### DIFF
--- a/mtp_api/apps/transaction/api/bank_admin/views.py
+++ b/mtp_api/apps/transaction/api/bank_admin/views.py
@@ -137,11 +137,12 @@ class ReconcileTransactionsView(generics.GenericAPIView):
         update_set.update(reconciled=True)
 
         for transaction in updated_transactions:
-            transaction.reconciled = True
-            transaction_reconciled.send(
-                sender=Transaction,
-                transaction=transaction,
-                by_user=request.user
-            )
+            if not transaction.reconciled:
+                transaction.reconciled = True
+                transaction_reconciled.send(
+                    sender=Transaction,
+                    transaction=transaction,
+                    by_user=request.user
+                )
 
         return Response(status=204)


### PR DESCRIPTION
Previously, each time a reconciliation file was downloaded,
another reconciliation log record was created for each transaction
in the file.