### PR TITLE
Create ref codes on reconciliation instead of creation

### DIFF
--- a/mtp_api/apps/transaction/tests/utils.py
+++ b/mtp_api/apps/transaction/tests/utils.py
@@ -277,7 +277,6 @@ def generate_transactions(
         for data in generate_predetermined_transactions_data():
             with MockModelTimestamps(data['created'], data['modified']):
                 new_transaction = Transaction.objects.create(**data)
-                new_transaction.populate_ref_code()
             transactions.append(new_transaction)
 
     generate_transaction_logs(transactions)
@@ -317,7 +316,6 @@ def setup_historical_transaction(location_creator, owner_status_chooser,
 
     with MockModelTimestamps(data['created'], data['modified']):
         new_transaction = Transaction.objects.create(**data)
-        new_transaction.populate_ref_code()
 
     return new_transaction
 
@@ -359,7 +357,6 @@ def setup_transaction(location_creator, owner_status_chooser,
 
     with MockModelTimestamps(data['created'], data['modified']):
         new_transaction = Transaction.objects.create(**data)
-        new_transaction.populate_ref_code()
 
     if data['source'] == TRANSACTION_SOURCE.ONLINE:
         payment = Payment()


### PR DESCRIPTION
This is due to the existence of unidentified transactions - those
which cannot be credited or refunded. As whether or not a transaction
can be credited is not known at the time of creation, we need to defer
the creation of ref codes until the point of reconciliation, after which
we know that the validity of the transaction will not change.