### PR TITLE
Deactivate users

### DIFF
--- a/mtp_api/apps/mtp_auth/tests/test_views.py
+++ b/mtp_api/apps/mtp_auth/tests/test_views.py
@@ -445,11 +445,11 @@ class DeleteUserTestCase(APITestCase, AuthTestCaseMixin):
 
     def _check_delete_user_succeeds(self, requester, username):
         self._delete_user(requester, username)
-        self.assertEqual(len(User.objects.filter(username=username)), 0)
+        self.assertFalse(User.objects.get(username=username).is_active)
 
     def _check_delete_user_fails(self, requester, username):
         self._delete_user(requester, username)
-        User.objects.get(username=username)
+        self.assertTrue(User.objects.get(username=username).is_active)
 
     def test_delete_bank_admin_bank_user_admin_succeeds(self):
         self._check_delete_user_succeeds(

--- a/mtp_api/apps/mtp_auth/views.py
+++ b/mtp_api/apps/mtp_auth/views.py
@@ -28,7 +28,8 @@ class UserViewSet(mixins.RetrieveModelMixin, mixins.ListModelMixin,
     def get_queryset(self):
         client_id = self.request.auth.application.client_id
         queryset = User.objects.filter(
-            applicationusermapping__application__client_id=client_id
+            applicationusermapping__application__client_id=client_id,
+            is_active=True
         )
 
         user_prisons = PrisonUserMapping.objects.get_prison_set_for_user(self.request.user)

--- a/mtp_api/apps/mtp_auth/views.py
+++ b/mtp_api/apps/mtp_auth/views.py
@@ -69,7 +69,8 @@ class UserViewSet(mixins.RetrieveModelMixin, mixins.ListModelMixin,
     def destroy(self, request, *args, **kwargs):
         user = self.get_object()
         if user != request.user:
-            self.perform_destroy(user)
+            user.is_active = False
+            user.save()
             return Response(status=status.HTTP_204_NO_CONTENT)
         else:
             return Response(


### PR DESCRIPTION
Deactivate instead of destroying users deleted by user admin. This is to preserve the audit trail.