### PR TITLE
Return the user self-deletion error as a list to match standard

### DIFF
--- a/mtp_api/apps/mtp_auth/views.py
+++ b/mtp_api/apps/mtp_auth/views.py
@@ -77,9 +77,7 @@ class UserViewSet(mixins.RetrieveModelMixin, mixins.ListModelMixin,
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={
-                    'errors': {
-                        '__all__': _('You cannot delete yourself.')
-                    }
+                    '__all__': [_('You cannot delete yourself.')]
                 },
             )
 


### PR DESCRIPTION
Django rest framework errors are returned as lists per field as
standard.