### PR TITLE
Make dashboard modules have a priority order

### DIFF
--- a/mtp_api/apps/core/dashboards.py
+++ b/mtp_api/apps/core/dashboards.py
@@ -11,6 +11,7 @@ class DashboardModule(metaclass=MediaDefiningClass):
     html_classes = 'mtp-dashboard-module module'
     title = _('Dashboard')
     enabled = True
+    priority = 0
     cookie_key = None
 
     def __init__(self, dashboard_view):

--- a/mtp_api/apps/core/views.py
+++ b/mtp_api/apps/core/views.py
@@ -94,7 +94,8 @@ class DashboardView(AdminViewMixin, TemplateView, metaclass=MediaDefiningClass):
 
         dashboards = map(lambda d: d(dashboard_view=self),
                          cls._registry)
-        return [dashboard for dashboard in dashboards if dashboard.enabled]
+        return sorted((dashboard for dashboard in dashboards if dashboard.enabled),
+                      key=lambda dashboard: dashboard.priority, reverse=True)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/mtp_api/apps/transaction/dashboards.py
+++ b/mtp_api/apps/transaction/dashboards.py
@@ -33,6 +33,7 @@ class TransactionReportDateForm(forms.Form):
 class TransactionReport(DashboardModule):
     template = 'core/dashboard/transaction-report.html'
     title = _('Transaction report')
+    priority = 100
     column_count = 3
     cookie_key = 'transaction-report'
 


### PR DESCRIPTION
so they're not displayed arbitrarily depending on module loading order