### PR TITLE
Allow path username parameter to include full stops

### DIFF
--- a/mtp_api/apps/mtp_auth/tests/test_views.py
+++ b/mtp_api/apps/mtp_auth/tests/test_views.py
@@ -37,6 +37,7 @@ class GetUserTestCase(APITestCase, AuthTestCaseMixin):
             self.prison_clerks + self.prisoner_location_admins +
             self.bank_admins + self.refund_bank_admins
         )
+        _, _, self.bank_uas = make_test_user_admins()
 
         self.prisons = Prison.objects.all()
 
@@ -105,6 +106,25 @@ class GetUserTestCase(APITestCase, AuthTestCaseMixin):
 
             self.assertEqual(response.data['pk'], user.pk)
             self.assertEqual(response.data['prisons'], [])
+
+    def test_all_valid_usernames_retrievable(self):
+        user_data = {
+            'username': 'dotted.name',
+            'first_name': 'New',
+            'last_name': 'User',
+            'email': 'user@mtp.local'
+        }
+        self.client.post(
+            reverse('user-list'),
+            format='json',
+            data=user_data,
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(self.bank_uas[0])
+        )
+        self.client.get(
+            self._get_url(user_data['username']),
+            format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(self.bank_uas[0])
+        )
 
 
 class ListUserTestCase(APITestCase, AuthTestCaseMixin):
@@ -207,7 +227,7 @@ class CreateUserTestCase(APITestCase, AuthTestCaseMixin):
             'username': 'new-bank-admin',
             'first_name': 'New',
             'last_name': 'Bank Admin',
-            'email': 'nba@mtp.gov.uk'
+            'email': 'nba@mtp.local'
         }
         response = self.client.post(
             self.get_url(),
@@ -261,7 +281,7 @@ class CreateUserTestCase(APITestCase, AuthTestCaseMixin):
             'username': 'new-bank-admin',
             'first_name': 'New',
             'last_name': 'Bank Admin',
-            'email': 'nba@mtp.gov.uk'
+            'email': 'nba@mtp.local'
         }
         self._check_create_user_succeeds(
             self.bank_uas[0],
@@ -276,7 +296,7 @@ class CreateUserTestCase(APITestCase, AuthTestCaseMixin):
             'username': 'new-prison-clerk',
             'first_name': 'New',
             'last_name': 'Prison Clerk',
-            'email': 'pc@mtp.gov.uk'
+            'email': 'pc@mtp.local'
         }
         self._check_create_user_succeeds(
             self.cashbook_uas[0],
@@ -290,7 +310,7 @@ class CreateUserTestCase(APITestCase, AuthTestCaseMixin):
             'username': 'new-cashbook-ua',
             'first_name': 'New',
             'last_name': 'Cashbook User Admin',
-            'email': 'cua@mtp.gov.uk',
+            'email': 'cua@mtp.local',
             'user_admin': True
         }
         self._check_create_user_succeeds(

--- a/mtp_api/apps/mtp_auth/views.py
+++ b/mtp_api/apps/mtp_auth/views.py
@@ -20,6 +20,7 @@ class UserViewSet(mixins.RetrieveModelMixin, mixins.ListModelMixin,
                   mixins.UpdateModelMixin, mixins.CreateModelMixin,
                   mixins.DestroyModelMixin, viewsets.GenericViewSet):
     lookup_field = 'username'
+    lookup_value_regex = '[^/]+'
 
     queryset = User.objects.none()
     permission_classes = (IsAuthenticated, UserPermissions)


### PR DESCRIPTION
Users can be created with full stops in their names and thus
it should be possible to query them.