### PR TITLE
Allow application-to-group mappings to be edited in Django admin

### DIFF
--- a/mtp_api/apps/mtp_auth/admin.py
+++ b/mtp_api/apps/mtp_auth/admin.py
@@ -5,11 +5,18 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
 
 from mtp_auth.forms import RestrictedUserChangeForm
-from mtp_auth.models import ApplicationUserMapping, PrisonUserMapping, FailedLoginAttempt
+from mtp_auth.models import ApplicationGroupMapping, ApplicationUserMapping, FailedLoginAttempt, PrisonUserMapping
 
 User = get_user_model()
 if admin.site.is_registered(User):
     admin.site.unregister(User)
+
+
+@admin.register(ApplicationGroupMapping)
+class ApplicationGroupMappingAdmin(ModelAdmin):
+    ordering = ('group__name', 'application')
+    list_display = ('group', 'application')
+    list_filter = ('application',)
 
 
 @admin.register(ApplicationUserMapping)


### PR DESCRIPTION
since there are no existing migrations or fixtures to create them automatically