### PR TITLE
Add recipient endpoint and use SQL for recipient and sender

### DIFF
--- a/mtp_api/apps/core/__init__.py
+++ b/mtp_api/apps/core/__init__.py
@@ -15,3 +15,8 @@ def getattr_path(obj, path, default=_not_provided):
     if path:
         return getattr_path(value, path, default=default)
     return value
+
+
+def dictfetchall(cursor):
+    columns = [col[0] for col in cursor.description]
+    return [dict(zip(columns, row)) for row in cursor.fetchall()]

--- a/mtp_api/apps/credit/serializers.py
+++ b/mtp_api/apps/credit/serializers.py
@@ -86,28 +86,33 @@ class LockedCreditSerializer(CreditSerializer):
         )
 
 
-class RecipientSerializer(serializers.Serializer):
+class BaseRecipientSerializer(serializers.Serializer):
     prisoner_number = serializers.CharField()
     prisoner_name = serializers.CharField()
-    credit_total = serializers.IntegerField()
-    credit_count = serializers.IntegerField()
 
     class Meta:
         fields = (
             'prisoner_number',
-            'prisoner_name',
+            'prisoner_name'
+        )
+
+
+class DetailRecipientSerializer(BaseRecipientSerializer):
+    credit_total = serializers.IntegerField()
+    credit_count = serializers.IntegerField()
+
+    class Meta:
+        fields = BaseRecipientSerializer.Meta.fields + (
             'credit_total',
             'credit_count',
         )
 
 
-class SenderSerializer(serializers.Serializer):
+class BaseSenderSerializer(serializers.Serializer):
     sender = serializers.CharField(required=False)
     sender_sort_code = serializers.CharField(required=False)
     sender_account_number = serializers.CharField(required=False)
     sender_roll_number = serializers.CharField(required=False)
-    recipient_count = serializers.IntegerField()
-    recipients = RecipientSerializer(many=True)
 
     class Meta:
         fields = (
@@ -115,6 +120,37 @@ class SenderSerializer(serializers.Serializer):
             'sender_sort_code',
             'sender_account_number',
             'sender_roll_number',
+        )
+
+
+class DetailSenderSerializer(BaseSenderSerializer):
+    credit_total = serializers.IntegerField()
+    credit_count = serializers.IntegerField()
+
+    class Meta:
+        fields = BaseSenderSerializer.Meta.fields + (
+            'credit_total',
+            'credit_count',
+        )
+
+
+class RecipientSerializer(BaseRecipientSerializer):
+    sender_count = serializers.IntegerField()
+    senders = DetailSenderSerializer(many=True)
+
+    class Meta:
+        fields = BaseRecipientSerializer.Meta.fields + (
+            'sender_count',
+            'senders',
+        )
+
+
+class SenderSerializer(BaseSenderSerializer):
+    recipient_count = serializers.IntegerField()
+    recipients = DetailRecipientSerializer(many=True)
+
+    class Meta:
+        fields = BaseSenderSerializer.Meta.fields + (
             'recipient_count',
             'recipients',
         )

--- a/mtp_api/apps/credit/urls.py
+++ b/mtp_api/apps/credit/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     url(r'^credits/actions/lock/$', views.LockCredits.as_view(), name='credit-lock'),
     url(r'^credits/actions/unlock/$', views.UnlockCredits.as_view(), name='credit-unlock'),
     url(r'^credits/senders/$', csrf_exempt(views.SenderList.as_view()), name='sender-list'),
+    url(r'^credits/recipients/$', csrf_exempt(views.RecipientList.as_view()), name='recipient-list'),
 ]


### PR DESCRIPTION
The switch to SQL is due to the fact that there is not much benefit
to using django ORM in this case, and it is arguably easier to
understand in this form.