### PR TITLE
Add a prison endpoint to retrieve prisons a user can access

### DIFF
--- a/mtp_api/apps/mtp_auth/serializers.py
+++ b/mtp_api/apps/mtp_auth/serializers.py
@@ -16,7 +16,6 @@ User = get_user_model()
 
 
 class UserSerializer(serializers.ModelSerializer):
-    prisons = serializers.SerializerMethodField()
     permissions = serializers.SerializerMethodField()
     user_admin = serializers.SerializerMethodField()
 
@@ -33,12 +32,6 @@ class UserSerializer(serializers.ModelSerializer):
         ))
 
         return fields
-
-    def get_prisons(self, obj):
-        return list(
-            PrisonUserMapping.objects.get_prison_set_for_user(obj)
-            .values_list('pk', flat=True)
-        )
 
     def get_permissions(self, obj):
         return obj.get_all_permissions()
@@ -122,7 +115,6 @@ class UserSerializer(serializers.ModelSerializer):
             'first_name',
             'last_name',
             'email',
-            'prisons',
             'permissions',
             'user_admin'
         )

--- a/mtp_api/apps/mtp_auth/tests/test_views.py
+++ b/mtp_api/apps/mtp_auth/tests/test_views.py
@@ -72,7 +72,7 @@ class GetUserTestCase(APITestCase, AuthTestCaseMixin):
             )
             self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_can_access_my_data_including_managing_prisons(self):
+    def test_can_access_my_data(self):
         for user in self.prison_clerks:
             url = self._get_url(user.username)
             response = self.client.get(
@@ -82,8 +82,6 @@ class GetUserTestCase(APITestCase, AuthTestCaseMixin):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
             self.assertEqual(response.data['pk'], user.pk)
-            prison_ids = list(user.prisonusermapping.prisons.values_list('pk', flat=True))
-            self.assertEqual(response.data['prisons'], prison_ids)
 
     def test_correct_permissions_returned(self):
         for user in self.test_users:
@@ -95,23 +93,6 @@ class GetUserTestCase(APITestCase, AuthTestCaseMixin):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
             self.assertEqual(response.data['permissions'], user.get_all_permissions())
-
-    def test_my_data_with_empty_prisons(self):
-        users = (
-            self.prisoner_location_admins +
-            self.bank_admins + self.refund_bank_admins
-        )
-
-        for user in users:
-            url = self._get_url(user.username)
-            response = self.client.get(
-                url, format='json',
-                HTTP_AUTHORIZATION=self.get_http_authorization_for_user(user)
-            )
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-            self.assertEqual(response.data['pk'], user.pk)
-            self.assertEqual(response.data['prisons'], [])
 
     def test_all_valid_usernames_retrievable(self):
         user_data = {

--- a/mtp_api/apps/prison/urls.py
+++ b/mtp_api/apps/prison/urls.py
@@ -7,6 +7,7 @@ router = routers.DefaultRouter()
 router.register(r'prisoner_locations', views.PrisonerLocationView)
 router.register(r'prisoner_validity', views.PrisonerValidityView,
                 base_name='prisoner_validity')
+router.register(r'prisons', views.PrisonView, base_name='prison')
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/mtp_api/apps/prison/views.py
+++ b/mtp_api/apps/prison/views.py
@@ -4,12 +4,13 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from core.permissions import ActionsBasedPermissions
+from mtp_auth.models import PrisonUserMapping
 from mtp_auth.permissions import (
     NomsOpsClientIDPermissions, SendMoneyClientIDPermissions
 )
 from prison.models import PrisonerLocation
 from prison.serializers import (
-    PrisonerLocationSerializer, PrisonerValiditySerializer
+    PrisonerLocationSerializer, PrisonerValiditySerializer, PrisonSerializer
 )
 
 
@@ -64,3 +65,14 @@ class PrisonerValidityView(mixins.ListModelMixin, viewsets.GenericViewSet):
                                             'fields are required'},
                             status=status.HTTP_400_BAD_REQUEST)
         return super().list(request, *args, **kwargs)
+
+
+class PrisonView(mixins.ListModelMixin, viewsets.GenericViewSet):
+    permission_classes = (IsAuthenticated,)
+    serializer_class = PrisonSerializer
+
+    def get_queryset(self):
+        return (
+            PrisonUserMapping.objects.get_prison_set_for_user(self.request.user)
+            .order_by('name')
+        )


### PR DESCRIPTION
Additionally, cease returning a list of prison IDs as part of the
authentication information as it is not used.