### PR TITLE
Add filtering on the amount of a credit for intelligence analysis

### DIFF
--- a/mtp_api/apps/credit/tests/utils.py
+++ b/mtp_api/apps/credit/tests/utils.py
@@ -1,4 +1,5 @@
 from itertools import cycle
+import random
 
 from django.contrib.auth import get_user_model
 
@@ -48,3 +49,10 @@ def create_credit_log(credit, created, modified):
         elif credit.locked:
             log_data['action'] = LOG_ACTIONS.LOCKED
             Log.objects.create(**log_data)
+
+
+def random_amount():
+    amount = random.randrange(500, 30000, 500)
+    if random.random() < 0.1:
+        amount += random.randint(0, 1000)
+    return amount

--- a/mtp_api/apps/credit/views.py
+++ b/mtp_api/apps/credit/views.py
@@ -83,7 +83,6 @@ class CreditTextSearchFilter(django_filters.CharFilter):
 
 
 class CreditListFilter(django_filters.FilterSet):
-
     status = StatusChoiceFilter(choices=CREDIT_STATUS.choices)
     prison = django_filters.ModelMultipleChoiceFilter(queryset=Prison.objects.all())
     prison_region = django_filters.CharFilter(name='prison__region')
@@ -96,10 +95,25 @@ class CreditListFilter(django_filters.FilterSet):
     sender_sort_code = django_filters.CharFilter(name='transaction__sender_sort_code')
     sender_account_number = django_filters.CharFilter(name='transaction__sender_account_number')
     sender_roll_number = django_filters.CharFilter(name='transaction__sender_roll_number')
+    exclude_amount__endswith = django_filters.CharFilter(
+        name='amount', lookup_expr='endswith', exclude=True
+    )
+    exclude_amount__regex = django_filters.CharFilter(
+        name='amount', lookup_expr='regex', exclude=True
+    )
+    amount__endswith = django_filters.CharFilter(
+        name='amount', lookup_expr='endswith'
+    )
+    amount__regex = django_filters.CharFilter(
+        name='amount', lookup_expr='regex'
+    )
 
     class Meta:
         model = Credit
-        fields = ('prisoner_number',)
+        fields = {
+            'prisoner_number': ['exact'],
+            'amount': ['exact', 'lte', 'gte']
+        }
 
 
 class CreditViewMixin(object):

--- a/mtp_api/apps/payment/tests/utils.py
+++ b/mtp_api/apps/payment/tests/utils.py
@@ -9,7 +9,9 @@ from faker import Faker
 from core.tests.utils import MockModelTimestamps
 from credit.constants import CREDIT_STATUS, CREDIT_RESOLUTION
 from credit.models import Credit
-from credit.tests.utils import get_owner_and_status_chooser, create_credit_log
+from credit.tests.utils import (
+    get_owner_and_status_chooser, create_credit_log, random_amount
+)
 from payment.constants import PAYMENT_STATUS
 from payment.models import Payment
 from prison.tests.utils import (
@@ -46,11 +48,11 @@ def generate_initial_payment_data(tot=50,
             minutes=random.randint(0, 10000)
         )
         random_date = timezone.localtime(random_date)
-        random_amount = random.randint(1000, 30000)
+        amount = random_amount()
         prisoner = next(prisoners)
         data = {
-            'amount': random_amount,
-            'service_charge': int(random_amount * 0.025),
+            'amount': amount,
+            'service_charge': int(amount * 0.025),
             'prisoner_name': prisoner['prisoner_name'],
             'prisoner_number': prisoner['prisoner_number'],
             'prisoner_dob': prisoner['prisoner_dob'],

--- a/mtp_api/apps/transaction/tests/utils.py
+++ b/mtp_api/apps/transaction/tests/utils.py
@@ -12,11 +12,14 @@ from faker import Faker
 from core.tests.utils import MockModelTimestamps
 from credit.constants import CREDIT_RESOLUTION, CREDIT_STATUS
 from credit.models import Credit
-from credit.tests.utils import get_owner_and_status_chooser, create_credit_log
+from credit.tests.utils import (
+    get_owner_and_status_chooser, create_credit_log, random_amount
+)
 from prison.models import PrisonerLocation
-from prison.tests.utils import random_prisoner_number, random_prisoner_dob, \
-    random_prisoner_name, get_prisoner_location_creator, \
-    load_nomis_prisoner_locations
+from prison.tests.utils import (
+    random_prisoner_number, random_prisoner_dob, random_prisoner_name,
+    get_prisoner_location_creator, load_nomis_prisoner_locations
+)
 from transaction.models import Transaction
 from transaction.constants import (
     TRANSACTION_CATEGORY, TRANSACTION_SOURCE
@@ -125,7 +128,7 @@ def generate_initial_transactions_data(
         random_sender = random.choice(senders)
         data = {
             'category': TRANSACTION_CATEGORY.CREDIT,
-            'amount': random.randint(1000, 30000),
+            'amount': random_amount(),
             'received_at': midnight_random_date,
             'sender_sort_code': random_sender['sort_code'],
             'sender_account_number': random_sender['account_number'],


### PR DESCRIPTION
This filtering can be on magnitude or on certain patterns such
as the least significant digits of a regex. These two pattern
types can also be excluded from the result set.