### PR TITLE
Use Q objects instead of dictionaries to build status filters

### DIFF
--- a/mtp_api/apps/core/filters.py
+++ b/mtp_api/apps/core/filters.py
@@ -5,5 +5,5 @@ class StatusChoiceFilter(django_filters.ChoiceFilter):
 
     def filter(self, qs, value):
         if value:
-            qs = qs.filter(**qs.model.STATUS_LOOKUP[value.lower()])
+            qs = qs.filter(qs.model.STATUS_LOOKUP[value.lower()])
         return qs

--- a/mtp_api/apps/credit/admin.py
+++ b/mtp_api/apps/credit/admin.py
@@ -64,7 +64,7 @@ class StatusFilter(admin.SimpleListFilter):
         status = self.used_parameters.get(self.parameter_name)
         if status in Credit.STATUS_LOOKUP:
             try:
-                return queryset.filter(**Credit.STATUS_LOOKUP[status])
+                return queryset.filter(Credit.STATUS_LOOKUP[status])
             except ValidationError as e:
                 raise IncorrectLookupParameters(e)
 

--- a/mtp_api/apps/credit/managers.py
+++ b/mtp_api/apps/credit/managers.py
@@ -6,19 +6,19 @@ from .constants import LOG_ACTIONS, CREDIT_STATUS
 class CreditQuerySet(models.QuerySet):
 
     def available(self):
-        return self.filter(**self.model.STATUS_LOOKUP[CREDIT_STATUS.AVAILABLE])
+        return self.filter(self.model.STATUS_LOOKUP[CREDIT_STATUS.AVAILABLE])
 
     def locked(self):
-        return self.filter(**self.model.STATUS_LOOKUP[CREDIT_STATUS.LOCKED])
+        return self.filter(self.model.STATUS_LOOKUP[CREDIT_STATUS.LOCKED])
 
     def credited(self):
-        return self.filter(**self.model.STATUS_LOOKUP[CREDIT_STATUS.CREDITED])
+        return self.filter(self.model.STATUS_LOOKUP[CREDIT_STATUS.CREDITED])
 
     def refunded(self):
-        return self.filter(**self.model.STATUS_LOOKUP[CREDIT_STATUS.REFUNDED])
+        return self.filter(self.model.STATUS_LOOKUP[CREDIT_STATUS.REFUNDED])
 
     def refund_pending(self):
-        return self.filter(**self.model.STATUS_LOOKUP[CREDIT_STATUS.REFUND_PENDING])
+        return self.filter(self.model.STATUS_LOOKUP[CREDIT_STATUS.REFUND_PENDING])
 
     def locked_by(self, user):
         return self.filter(owner=user)

--- a/mtp_api/apps/credit/models.py
+++ b/mtp_api/apps/credit/models.py
@@ -44,25 +44,25 @@ class Credit(TimeStampedModel):
     objects = CreditManager.from_queryset(CreditQuerySet)()
 
     STATUS_LOOKUP = {
-        CREDIT_STATUS.LOCKED: {
-            'owner__isnull': False,
-            'resolution': CREDIT_RESOLUTION.PENDING,
-        },
-        CREDIT_STATUS.AVAILABLE: {
-            'prison__isnull': False,
-            'owner__isnull': True,
-            'resolution': CREDIT_RESOLUTION.PENDING,
-        },
-        CREDIT_STATUS.CREDITED: {
-            'resolution': CREDIT_RESOLUTION.CREDITED,
-        },
-        CREDIT_STATUS.REFUNDED: {
-            'resolution': CREDIT_RESOLUTION.REFUNDED,
-        },
-        CREDIT_STATUS.REFUND_PENDING: {
-            'prison__isnull': True,
-            'resolution': CREDIT_RESOLUTION.PENDING,
-        },
+        CREDIT_STATUS.LOCKED: (
+            models.Q(owner__isnull=False) &
+            models.Q(resolution=CREDIT_RESOLUTION.PENDING)
+        ),
+        CREDIT_STATUS.AVAILABLE: (
+            models.Q(prison__isnull=False) &
+            models.Q(owner__isnull=True) &
+            models.Q(resolution=CREDIT_RESOLUTION.PENDING)
+        ),
+        CREDIT_STATUS.CREDITED: (
+            models.Q(resolution=CREDIT_RESOLUTION.CREDITED)
+        ),
+        CREDIT_STATUS.REFUNDED: (
+            models.Q(resolution=CREDIT_RESOLUTION.REFUNDED)
+        ),
+        CREDIT_STATUS.REFUND_PENDING: (
+            models.Q(prison__isnull=True) &
+            models.Q(resolution=CREDIT_RESOLUTION.PENDING)
+        ),
     }
 
     def __str__(self):

--- a/mtp_api/apps/credit/views.py
+++ b/mtp_api/apps/credit/views.py
@@ -244,7 +244,7 @@ class LockedCreditList(CreditViewMixin, generics.ListAPIView):
     def get_queryset(self):
         queryset = super().get_queryset()
         return queryset.filter(
-            **Credit.STATUS_LOOKUP[CREDIT_STATUS.LOCKED]
+            Credit.STATUS_LOOKUP[CREDIT_STATUS.LOCKED]
         )
 
 

--- a/mtp_api/apps/transaction/admin.py
+++ b/mtp_api/apps/transaction/admin.py
@@ -19,7 +19,7 @@ class StatusFilter(admin.SimpleListFilter):
         status = self.used_parameters.get(self.parameter_name)
         if status in Transaction.STATUS_LOOKUP:
             try:
-                return queryset.filter(**Transaction.STATUS_LOOKUP[status])
+                return queryset.filter(Transaction.STATUS_LOOKUP[status])
             except ValidationError as e:
                 raise IncorrectLookupParameters(e)
 

--- a/mtp_api/apps/transaction/dashboards.py
+++ b/mtp_api/apps/transaction/dashboards.py
@@ -22,13 +22,13 @@ from transaction.models import Transaction
 from transaction.utils import format_amount, format_number
 
 CREDITABLE_FILTERS = Transaction.STATUS_LOOKUP[TRANSACTION_STATUS.CREDITABLE]
-CREDITED_FILTERS = {
-    'credit__resolution': CREDIT_RESOLUTION.CREDITED,
-}
+CREDITED_FILTERS = (
+    models.Q(credit__resolution=CREDIT_RESOLUTION.CREDITED)
+)
 REFUNDABLE_FILTERS = Transaction.STATUS_LOOKUP[TRANSACTION_STATUS.REFUNDABLE]
-REFUNDED_FILTERS = {
-    'credit__resolution': CREDIT_RESOLUTION.REFUNDED
-}
+REFUNDED_FILTERS = (
+    models.Q(credit__resolution=CREDIT_RESOLUTION.REFUNDED)
+)
 UNIDENTIFIED_FILTERS = Transaction.STATUS_LOOKUP[TRANSACTION_STATUS.UNIDENTIFIED]
 
 
@@ -105,8 +105,8 @@ class TransactionReportChart:
             if date.weekday() > 4:
                 self.weekends.append(date)
             transactions = self.queryset.filter(received_at__date=date)
-            creditable = transactions.filter(**CREDITABLE_FILTERS).count() or 0
-            refundable = transactions.filter(**REFUNDABLE_FILTERS).count() or 0
+            creditable = transactions.filter(CREDITABLE_FILTERS).count() or 0
+            refundable = transactions.filter(REFUNDABLE_FILTERS).count() or 0
             data.append([date, creditable, refundable])
             max_sum = creditable + refundable
             if max_sum >= self.max_sum:
@@ -219,23 +219,23 @@ class TransactionReport(DashboardModule):
 
     @property
     def creditable(self):
-        return self.queryset.filter(**CREDITABLE_FILTERS)
+        return self.queryset.filter(CREDITABLE_FILTERS)
 
     @property
     def credited(self):
-        return self.queryset.filter(**CREDITED_FILTERS)
+        return self.queryset.filter(CREDITED_FILTERS)
 
     @property
     def refundable(self):
-        return self.queryset.filter(**REFUNDABLE_FILTERS)
+        return self.queryset.filter(REFUNDABLE_FILTERS)
 
     @property
     def refunded(self):
-        return self.queryset.filter(**REFUNDED_FILTERS)
+        return self.queryset.filter(REFUNDED_FILTERS)
 
     @property
     def unidentified(self):
-        return self.queryset.filter(**UNIDENTIFIED_FILTERS)
+        return self.queryset.filter(UNIDENTIFIED_FILTERS)
 
     @property
     def well_formed_references(self):

--- a/mtp_api/apps/transaction/models.py
+++ b/mtp_api/apps/transaction/models.py
@@ -36,24 +36,24 @@ class Transaction(TimeStampedModel):
 
     # NB: there are matching boolean fields or properties on the model instance for each
     STATUS_LOOKUP = {
-        TRANSACTION_STATUS.CREDITABLE: {
-            'credit__prison__isnull': False
-        },
-        TRANSACTION_STATUS.REFUNDABLE: {
-            'credit__isnull': False,
-            'credit__prison__isnull': True,
-            'incomplete_sender_info': False
-        },
-        TRANSACTION_STATUS.UNIDENTIFIED: {
-            'credit__prison__isnull': True,
-            'incomplete_sender_info': True,
-            'category': TRANSACTION_CATEGORY.CREDIT,
-            'source': TRANSACTION_SOURCE.BANK_TRANSFER
-        },
-        TRANSACTION_STATUS.ANOMALOUS: {
-            'category': TRANSACTION_CATEGORY.CREDIT,
-            'source': TRANSACTION_SOURCE.ADMINISTRATIVE
-        }
+        TRANSACTION_STATUS.CREDITABLE: (
+            models.Q(credit__prison__isnull=False)
+        ),
+        TRANSACTION_STATUS.REFUNDABLE: (
+            models.Q(credit__isnull=False) &
+            models.Q(credit__prison__isnull=True) &
+            models.Q(incomplete_sender_info=False)
+        ),
+        TRANSACTION_STATUS.UNIDENTIFIED: (
+            models.Q(credit__prison__isnull=True) &
+            models.Q(incomplete_sender_info=True) &
+            models.Q(category=TRANSACTION_CATEGORY.CREDIT) &
+            models.Q(source=TRANSACTION_SOURCE.BANK_TRANSFER)
+        ),
+        TRANSACTION_STATUS.ANOMALOUS: (
+            models.Q(category=TRANSACTION_CATEGORY.CREDIT) &
+            models.Q(source=TRANSACTION_SOURCE.ADMINISTRATIVE)
+        )
     }
 
     objects = TransactionQuerySet.as_manager()
@@ -83,11 +83,11 @@ class Transaction(TimeStampedModel):
 
     @property
     def credited(self):
-        return self.credit and self.credit.credited
+        return self.credit.credited if self.credit else False
 
     @property
     def refunded(self):
-        return self.credit and self.credit.refunded
+        return self.credit.refunded if self.credit else False
 
     @property
     def prison(self):

--- a/mtp_api/apps/transaction/serializers.py
+++ b/mtp_api/apps/transaction/serializers.py
@@ -86,8 +86,8 @@ class UpdateTransactionListSerializer(serializers.ListSerializer):
 
     def refund(self, user, to_refund):
         update_set = Credit.objects.filter(
-            transaction__pk__in=to_refund,
-            **Credit.STATUS_LOOKUP['refund_pending']).select_for_update()
+            Credit.STATUS_LOOKUP['refund_pending'],
+            transaction__pk__in=to_refund).select_for_update()
         if len(update_set) != len(to_refund):
             raise Credit.DoesNotExist(
                 list(set(to_refund) - {c.transaction.id for c in update_set})

--- a/mtp_api/apps/transaction/tests/test_dashboard.py
+++ b/mtp_api/apps/transaction/tests/test_dashboard.py
@@ -40,8 +40,8 @@ class TransactionDashboardTestCase(DashboardTestCase):
         response = self.client.get(url)
         self.assertContains(response, 'Latest transactions received on')
         transactions = Transaction.objects.filter(
-            received_at__date=localtime(Transaction.objects.latest().received_at).date(),
-            **Transaction.STATUS_LOOKUP[TRANSACTION_STATUS.CREDITABLE]
+            Transaction.STATUS_LOOKUP[TRANSACTION_STATUS.CREDITABLE],
+            received_at__date=localtime(Transaction.objects.latest().received_at).date()
         )
         creditable_amount = transactions.aggregate(amount=models.Sum('amount'))['amount']
         self.assertAmountInContent(creditable_amount, response)
@@ -52,7 +52,7 @@ class TransactionDashboardTestCase(DashboardTestCase):
         response = self.client.get(url)
         self.assertContains(response, 'All transactions')
         transactions = Transaction.objects.filter(
-            **Transaction.STATUS_LOOKUP[TRANSACTION_STATUS.CREDITABLE]
+            Transaction.STATUS_LOOKUP[TRANSACTION_STATUS.CREDITABLE]
         )
         creditable_amount = transactions.aggregate(amount=models.Sum('amount'))['amount']
         self.assertAmountInContent(creditable_amount, response)

--- a/mtp_api/apps/transaction/tests/test_views.py
+++ b/mtp_api/apps/transaction/tests/test_views.py
@@ -298,7 +298,7 @@ class UpdateRefundTransactionsTestCase(
         user = self._get_authorised_user()
 
         invalid_transactions = Transaction.objects.filter(
-            **Transaction.STATUS_LOOKUP[status])
+            Transaction.STATUS_LOOKUP[status])
         invalid_data_list = (
             [{'id': t.id, 'refunded': True} for t in invalid_transactions]
         )
@@ -409,7 +409,7 @@ class GetTransactionsAsBankAdminTestCase(GetTransactionsBaseTestCase):
 
         # check that all matching db records are returned
         ts = list(Transaction.objects.filter(
-            **Transaction.STATUS_LOOKUP[status]))
+            Transaction.STATUS_LOOKUP[status]))
         db_ids = [t.id for t in ts]
         self.assertEqual(len(set(db_ids)), len(data['results']))
 
@@ -418,8 +418,7 @@ class GetTransactionsAsBankAdminTestCase(GetTransactionsBaseTestCase):
             matches_one = False
             try:
                 Transaction.objects.get(
-                    id=t['id'],
-                    **Transaction.STATUS_LOOKUP[status])
+                    Transaction.STATUS_LOOKUP[status], id=t['id'])
                 matches_one = True
                 break
             except Transaction.DoesNotExist:
@@ -502,7 +501,7 @@ class GetTransactionsRelatedToBatchesTestCase(GetTransactionsBaseTestCase):
         adi_batch.save()
 
         adi_batch.transactions = list(Transaction.objects.filter(
-            **Transaction.STATUS_LOOKUP['refundable']))
+            Transaction.STATUS_LOOKUP['refundable']))
         adi_batch.save()
 
         response = self.client.get(
@@ -539,7 +538,7 @@ class GetTransactionsRelatedToBatchesTestCase(GetTransactionsBaseTestCase):
         adi_batch.save()
 
         refunded_trans = list(Transaction.objects.filter(
-            **Transaction.STATUS_LOOKUP['refundable']))
+            Transaction.STATUS_LOOKUP['refundable']))
         attached = [a for (i, a) in enumerate(refunded_trans) if i % 2]
         unattached = [a for (i, a) in enumerate(refunded_trans) if not i % 2]
         self.assertTrue(len(attached) >= 1)
@@ -574,7 +573,7 @@ class GetTransactionsRelatedToBatchesTestCase(GetTransactionsBaseTestCase):
         adi_batch.save()
 
         refunded_trans = list(Transaction.objects.filter(
-            **Transaction.STATUS_LOOKUP['refundable']))
+            Transaction.STATUS_LOOKUP['refundable']))
         attached = [a for (i, a) in enumerate(refunded_trans) if i % 2]
         self.assertTrue(len(attached) >= 1)
 


### PR DESCRIPTION
This allows for more flexibility in status definitions e.g.
OR as well as AND, subclauses etc.