### PR TITLE
Reject anonymous payments

### DIFF
--- a/mtp_api/apps/credit/views.py
+++ b/mtp_api/apps/credit/views.py
@@ -279,7 +279,7 @@ class LockCredits(CreditViewMixin, APIView):
             locked_count = self.get_queryset().locked().filter(owner=self.request.user).count()
             if locked_count < LOCK_LIMIT:
                 slice_size = LOCK_LIMIT-locked_count
-                to_lock = self.get_queryset().available().select_for_update()
+                to_lock = self.get_queryset().available()
                 slice_pks = to_lock.values_list('pk', flat=True)[:slice_size]
 
                 queryset = self.get_queryset().filter(pk__in=slice_pks)

--- a/mtp_api/apps/transaction/tests/test_views.py
+++ b/mtp_api/apps/transaction/tests/test_views.py
@@ -413,17 +413,10 @@ class GetTransactionsAsBankAdminTestCase(GetTransactionsBaseTestCase):
         db_ids = [t.id for t in ts]
         self.assertEqual(len(set(db_ids)), len(data['results']))
 
-        # check that all results match one of the provided statuses
+        # check that all results match the provided status
         for t in data['results']:
-            matches_one = False
-            try:
-                Transaction.objects.get(
-                    Transaction.STATUS_LOOKUP[status], id=t['id'])
-                matches_one = True
-                break
-            except Transaction.DoesNotExist:
-                pass
-            self.assertTrue(matches_one)
+            self.assertEqual(Transaction.objects.filter(
+                Transaction.STATUS_LOOKUP[status], id=t['id']).count(), 1)
 
         return data['results']
 
@@ -449,6 +442,7 @@ class GetTransactionsAsBankAdminTestCase(GetTransactionsBaseTestCase):
         results = self._test_get_list_with_status(status)
         self._assert_required_fields_present(results)
         self._assert_hidden_fields_absent(results)
+        return results
 
     def test_get_list_all(self):
         data = self._get_with_status(self._get_authorised_user(), '')

--- a/mtp_api/apps/transaction/tests/utils.py
+++ b/mtp_api/apps/transaction/tests/utils.py
@@ -168,8 +168,9 @@ def generate_initial_transactions_data(
                 if data.get('sender_roll_number'):
                     del data['sender_roll_number']
                 else:
-                    del data['sender_sort_code']
                     del data['sender_account_number']
+                    if transaction_counter % 2 == 0:
+                        del data['sender_sort_code']
 
             data['reference'] = random_reference(
                 data.get('prisoner_number'), data.get('prisoner_dob')


### PR DESCRIPTION
Any payment which has incomplete sender information will no longer
be credited to a prisoner, even if it is possible to identify the
prisoner for whom it is intended. Instead it will be classified as
an 'unidentified' payment and no automatic action will be taken.

Payments lacking sender information which have been credited in the
past will still show up as successful payments.