### PR TITLE
No prison filtering

### DIFF
--- a/mtp_api/apps/credit/tests/test_views.py
+++ b/mtp_api/apps/credit/tests/test_views.py
@@ -78,6 +78,9 @@ class CreditListTestCase(
         if filters.get('prison'):
             def prison_checker(c):
                 return c.prison and c.prison.pk in filters['prison'].split(',')
+        elif filters.get('prison__isnull'):
+            def prison_checker(c):
+                return (c.prison is None) == (filters['prison__isnull'] == 'True')
         else:
             prison_checker = noop_checker
         if filters.get('user'):
@@ -1093,6 +1096,14 @@ class AmountPatternCreditListTestCase(SecurityCreditListTestCase):
         random_amount = random.choice(self.credits).amount
         self._test_response_with_filters(filters={
             'amount': random_amount,
+        })
+
+
+class NoPrisonCreditListTestCase(SecurityCreditListTestCase):
+
+    def test_no_prison_filter(self):
+        self._test_response_with_filters(filters={
+            'prison__isnull': 'True'
         })
 
 

--- a/mtp_api/apps/credit/tests/test_views.py
+++ b/mtp_api/apps/credit/tests/test_views.py
@@ -1491,6 +1491,22 @@ class GroupedListTestCase(BaseCreditViewTestCase):
         )
         return response
 
+    def _test_get_grouped_subset_ordered_correctly(self, subset_field, ordering_field):
+        response = self._get_grouped_response()
+
+        for prisoner in response.data['results']:
+            # check ordering, with nulls last
+            in_null_tail = False
+            previous_ordering_field = ''
+            for sender in prisoner[subset_field]:
+                if sender[ordering_field]:
+                    if in_null_tail:
+                        self.fail('null %s occurs before end of list' % ordering_field)
+                    self.assertGreaterEqual(sender[ordering_field], previous_ordering_field)
+                    previous_ordering_field = sender[ordering_field]
+                else:
+                    in_null_tail = True
+
     def test_ordering(self):
         if not self.ordering:
             return
@@ -1568,6 +1584,9 @@ class SenderListTestCase(GroupedListTestCase):
                                  len(sender['prisoners']))
                 for prisoner in sender['prisoners']:
                     self.assertNotEqual(prisoner['prisoner_number'], None)
+
+    def test_get_senders_prisoners_ordered_correctly(self):
+        self._test_get_grouped_subset_ordered_correctly('prisoners', 'prisoner_number')
 
     def test_get_senders_prisoners_correct_credit_totals(self):
         response = self._get_grouped_response()
@@ -1650,18 +1669,21 @@ class PrisonerListTestCase(GroupedListTestCase):
 
         for prisoner in response.data['results']:
             # check sender_count is correct (not including refunds)
-            sender_count = Credit.objects.filter(
+            senders = Credit.objects.filter(
                 prisoner_number=prisoner['prisoner_number'],
             ).values(
                 'transaction__sender_name',
                 'transaction__sender_sort_code',
                 'transaction__sender_account_number',
                 'transaction__sender_roll_number',
-            ).distinct().count()
+            ).distinct()
             self.assertEqual(
-                sender_count,
+                senders.count(),
                 prisoner['sender_count']
             )
+
+    def test_get_prisoners_senders_ordered_correctly(self):
+        self._test_get_grouped_subset_ordered_correctly('senders', 'sender_name')
 
     def test_get_prisoners_min_sender_count_with_prison_filter(self):
         min_sender_count = 2

--- a/mtp_api/apps/credit/views.py
+++ b/mtp_api/apps/credit/views.py
@@ -465,6 +465,11 @@ class SenderList(CreditViewMixin, GroupedListAPIView):
                 if add_new_prisoner:
                     last_sender['prisoners'].append(prisoner)
             else:
+                if last_sender:
+                    last_sender['prisoners'] = sorted(
+                        last_sender['prisoners'],
+                        key=lambda p: (p['prisoner_number'] or '\uffff').lower()
+                    )
                 last_sender = {
                     key: credit_group[key]
                     for key in sender_identifiers
@@ -575,6 +580,11 @@ class PrisonerList(CreditViewMixin, GroupedListAPIView):
                                      for key in prisoner_identifiers):
                 last_prisoner['senders'].append(sender)
             else:
+                if last_prisoner:
+                    last_prisoner['senders'] = sorted(
+                        last_prisoner['senders'],
+                        key=lambda s: (s['sender_name'] or '\uffff').lower()
+                    )
                 last_prisoner = {
                     key: credit_group[key]
                     for key in prisoner_identifiers

--- a/mtp_api/apps/credit/views.py
+++ b/mtp_api/apps/credit/views.py
@@ -92,6 +92,7 @@ class CreditListFilter(django_filters.FilterSet):
     status = StatusChoiceFilter(choices=CREDIT_STATUS.choices)
     prisoner_name = django_filters.CharFilter(name='prisoner_name', lookup_expr='icontains')
     prison = django_filters.ModelMultipleChoiceFilter(queryset=Prison.objects.all())
+    prison__isnull = django_filters.BooleanFilter(name='prison', lookup_expr='isnull')
     prison_region = django_filters.CharFilter(name='prison__region')
     prison_gender = django_filters.CharFilter(name='prison__gender')
     user = django_filters.ModelChoiceFilter(name='owner', queryset=User.objects.all())


### PR DESCRIPTION
Allow for specifying a null prison as a credit filter, and order returned
subsets of grouped queries, with null values coming last.