### PR TITLE
Make all test email addresses @mtp.local or @outside.local

### DIFF
--- a/mtp_api/apps/core/management/commands/testserver.py
+++ b/mtp_api/apps/core/management/commands/testserver.py
@@ -82,7 +82,7 @@ class Command(TestServerCommand):
         except User.DoesNotExist:
             admin_user = User.objects.create_superuser(
                 username='admin',
-                email='admin@local',
+                email='admin@mtp.local',
                 password='admin',
                 first_name='Admin',
                 last_name='User',

--- a/mtp_api/apps/core/tests/test_permissions.py
+++ b/mtp_api/apps/core/tests/test_permissions.py
@@ -47,8 +47,8 @@ def basic_auth_header(username, password):
 class BaseActionsBasedPermissionsTests(TestCase):
 
     def setUp(self):
-        User.objects.create_user('disallowed', 'disallowed@example.com', 'password')
-        user = User.objects.create_user('permitted', 'permitted@example.com', 'password')
+        User.objects.create_user('disallowed', 'disallowed@outside.local', 'password')
+        user = User.objects.create_user('permitted', 'permitted@mtp.local', 'password')
         user.user_permissions = [
             Permission.objects.get(codename='add_group'),
             Permission.objects.get(codename='change_group'),


### PR DESCRIPTION
so that email sending functions can filter these out and not flood MailGun with errors