### PR TITLE
Remove API-side validation that the user can access the client application

### DIFF
--- a/mtp_api/apps/mtp_auth/tests/test_views.py
+++ b/mtp_api/apps/mtp_auth/tests/test_views.py
@@ -614,66 +614,6 @@ class DeleteUserTestCase(APITestCase, AuthTestCaseMixin):
         )
 
 
-class UserApplicationValidationTestCase(APITestCase):
-    fixtures = ['test_prisons.json', 'initial_groups.json']
-
-    def setUp(self):
-        super(UserApplicationValidationTestCase, self).setUp()
-        self.prison_clerks, self.users, self.bank_admins, _, _, _ = make_test_users()
-
-    def test_prison_clerk_can_log_in_to_cashbook(self):
-        response = self.client.post(
-            reverse('oauth2_provider:token'),
-            {
-                'grant_type': 'password',
-                'username': self.prison_clerks[0].username,
-                'password': self.prison_clerks[0].username,
-                'client_id': CASHBOOK_OAUTH_CLIENT_ID,
-                'client_secret': CASHBOOK_OAUTH_CLIENT_ID,
-            }
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-    def test_bank_admin_can_log_in_to_bank_admin(self):
-        response = self.client.post(
-            reverse('oauth2_provider:token'),
-            {
-                'grant_type': 'password',
-                'username': self.bank_admins[0].username,
-                'password': self.bank_admins[0].username,
-                'client_id': BANK_ADMIN_OAUTH_CLIENT_ID,
-                'client_secret': BANK_ADMIN_OAUTH_CLIENT_ID,
-            }
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-    def test_prison_clerk_cannot_login_to_bank_admin(self):
-        response = self.client.post(
-            reverse('oauth2_provider:token'),
-            {
-                'grant_type': 'password',
-                'username': self.prison_clerks[0].username,
-                'password': self.prison_clerks[0].username,
-                'client_id': BANK_ADMIN_OAUTH_CLIENT_ID,
-                'client_secret': BANK_ADMIN_OAUTH_CLIENT_ID,
-            }
-        )
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
-    def test_bank_admin_cannot_login_to_cashbook(self):
-        response = self.client.post(
-            reverse('oauth2_provider:token'),
-            {
-                'grant_type': 'password',
-                'username': self.bank_admins[0].username,
-                'password': self.bank_admins[0].username,
-                'client_id': CASHBOOK_OAUTH_CLIENT_ID,
-                'client_secret': CASHBOOK_OAUTH_CLIENT_ID,
-            }
-        )
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
-
 class AccountLockoutTestCase(APITestCase):
     fixtures = ['test_prisons.json', 'initial_groups.json']
 

--- a/mtp_api/apps/mtp_auth/validators.py
+++ b/mtp_api/apps/mtp_auth/validators.py
@@ -3,7 +3,7 @@ import logging
 from django.contrib.auth import get_user_model, user_logged_in
 from oauth2_provider.oauth2_validators import OAuth2Validator
 
-from .models import ApplicationUserMapping, FailedLoginAttempt
+from .models import FailedLoginAttempt
 
 logger = logging.getLogger('mtp')
 
@@ -23,8 +23,7 @@ class ApplicationRequestValidator(OAuth2Validator):
             valid = super().validate_user(
                 username, password, client, request, *args, **kwargs
             )
-            if valid and ApplicationUserMapping.objects.filter(
-                    user=request.user, application=client).exists():
+            if valid:
                 FailedLoginAttempt.objects.delete_failed_attempts(user, client)
                 user_logged_in.send(sender=user.__class__, request=request, user=user)
                 return True


### PR DESCRIPTION
This is now checked by the client application. This is considered to be
sufficient as it makes sense for the client to handle access to itself.
The only additional attack vector that I can think of is if someone had
e.g. a bank admin's user credentials and the client id/secret for a
different app then they could obtain an oauth token, but they could
do the same simply by logging in to the bank admin app, so nbd.