### PR TITLE
Return a forbidden response for login attempt in disallowed application

### DIFF
--- a/mtp_api/apps/mtp_auth/validators.py
+++ b/mtp_api/apps/mtp_auth/validators.py
@@ -2,6 +2,7 @@ import logging
 
 from django.contrib.auth import get_user_model, user_logged_in
 from oauth2_provider.oauth2_validators import OAuth2Validator
+from oauthlib.oauth2 import OAuth2Error
 
 from .models import ApplicationUserMapping, FailedLoginAttempt
 
@@ -10,6 +11,12 @@ logger = logging.getLogger('mtp')
 
 class LockedOut(Exception):
     pass
+
+
+class RestrictedClientError(OAuth2Error):
+    """The authenticated user is not authorized to access this client"""
+    error = 'restricted_client'
+    status_code = 403
 
 
 class ApplicationRequestValidator(OAuth2Validator):
@@ -23,8 +30,10 @@ class ApplicationRequestValidator(OAuth2Validator):
             valid = super().validate_user(
                 username, password, client, request, *args, **kwargs
             )
-            if valid and ApplicationUserMapping.objects.filter(
-                    user=request.user, application=client).exists():
+            if valid:
+                if not ApplicationUserMapping.objects.filter(
+                        user=request.user, application=client).exists():
+                    raise RestrictedClientError(request=request)
                 FailedLoginAttempt.objects.delete_failed_attempts(user, client)
                 user_logged_in.send(sender=user.__class__, request=request, user=user)
                 return True


### PR DESCRIPTION
If a user attempts to access a client application which they do not
have permission to access, a 403 response will be returned rather
than a 401. This is to allow us to handle error messaging to the
user differently.