### PR TITLE
Optimisations

### DIFF
--- a/mtp_api/apps/account/serializers.py
+++ b/mtp_api/apps/account/serializers.py
@@ -10,9 +10,13 @@ class BatchSerializer(serializers.ModelSerializer):
 
         transactions = validated_data.pop('transactions')
         batch = Batch.objects.create(user=user, **validated_data)
-        for transaction in transactions:
-            batch.transactions.add(transaction)
+        batch.transactions.add(*transactions)
         return batch
+
+    def update(self, instance, validated_data):
+        transactions = validated_data.pop('transactions')
+        instance.transactions.add(*transactions)
+        return super().update(instance, validated_data)
 
     class Meta:
         model = Batch

--- a/mtp_api/apps/account/views.py
+++ b/mtp_api/apps/account/views.py
@@ -8,7 +8,8 @@ from .serializers import BatchSerializer, BalanceSerializer
 
 
 class BatchView(
-    mixins.CreateModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet
+    mixins.CreateModelMixin, mixins.UpdateModelMixin,
+    mixins.ListModelMixin, viewsets.GenericViewSet
 ):
     queryset = Batch.objects.all().order_by('-created')
     serializer_class = BatchSerializer

--- a/mtp_api/apps/mtp_auth/fixtures/initial_groups.json
+++ b/mtp_api/apps/mtp_auth/fixtures/initial_groups.json
@@ -19,6 +19,7 @@
       ["view_transaction", "transaction", "transaction"],
       ["patch_processed_transaction", "transaction", "transaction"],
       ["add_batch", "account", "batch"],
+      ["change_batch", "account", "batch"],
       ["add_balance", "account", "balance"]
     ]
   }

--- a/mtp_api/apps/transaction/constants.py
+++ b/mtp_api/apps/transaction/constants.py
@@ -16,7 +16,10 @@ TRANSACTION_STATUS = Choices(
     ('UNIDENTIFIED', 'unidentified', _('Unidentified')),
 
     # transactions of an unknown type
-    ('ANOMALOUS', 'anomalous', _('Anomalous'))
+    ('ANOMALOUS', 'anomalous', _('Anomalous')),
+
+    # transactions that can be reconciled
+    ('RECONCILABLE', 'reconcilable', _('Reconcilable'))
 )
 
 TRANSACTION_CATEGORY = Choices(

--- a/mtp_api/apps/transaction/managers.py
+++ b/mtp_api/apps/transaction/managers.py
@@ -1,8 +1,10 @@
-from datetime import timedelta
-
 from django.conf import settings
+from django.db import connection
 from django.db import models
 from django.db.transaction import atomic
+
+from credit.models import Credit
+from .constants import TRANSACTION_STATUS
 
 
 class TransactionQuerySet(models.QuerySet):
@@ -10,16 +12,28 @@ class TransactionQuerySet(models.QuerySet):
     @atomic
     def reconcile(self, date, user):
         update_set = self.filter(
-            received_at__gte=date,
-            received_at__lt=(date + timedelta(days=1)),
+            self.model.STATUS_LOOKUP[TRANSACTION_STATUS.RECONCILABLE],
+            received_at__date=date.date(),
             credit__isnull=False,
             credit__reconciled=False
         ).order_by('id').select_for_update()
 
+        ref_codes = []
         ref_code = settings.REF_CODE_BASE
         for transaction in update_set:
-            if transaction.reconcilable:
-                transaction.ref_code = ref_code
-                ref_code += 1
-            transaction.credit.reconcile(user)
-            transaction.save()
+            ref_codes.append((transaction.id, ref_code))
+            ref_code += 1
+
+        if ref_codes:
+            with connection.cursor() as c:
+                c.execute('DROP TABLE IF EXISTS refids;')
+                c.execute('CREATE TEMP TABLE refids (id integer, ref_code integer)')
+                insert_query = 'INSERT INTO refids (id, ref_code) VALUES '
+                insert_query += ', '.join(['%s' for _ in ref_codes])
+                insert_query += ';'
+                c.execute(insert_query, ref_codes)
+                c.execute('UPDATE transaction_transaction t SET '
+                          'ref_code=r.ref_code FROM refids r WHERE '
+                          't.id=r.id;')
+
+        Credit.objects.reconcile(date, user)

--- a/mtp_api/apps/transaction/models.py
+++ b/mtp_api/apps/transaction/models.py
@@ -72,6 +72,11 @@ class Transaction(TimeStampedModel):
         )
     }
 
+    STATUS_LOOKUP[TRANSACTION_STATUS.RECONCILABLE] = ~(
+        STATUS_LOOKUP[TRANSACTION_STATUS.UNIDENTIFIED] |
+        STATUS_LOOKUP[TRANSACTION_STATUS.ANOMALOUS]
+    )
+
     objects = TransactionQuerySet.as_manager()
 
     class Meta:


### PR DESCRIPTION
* Allow for a batch to be updated after intial creation
  * This means that not all transactions have to be included in the create request, allowing for batching of large numbers of transactions.
* Optimise the reconciliation of transactions
  * Process credits and transactions separately
  * Bulk update credits to reconciled, and bulk create credit reconciliation
logs
  * Use temp table insert to do bulk update of generated ref codes on
transactions