### PR TITLE
Make the received_at range filter syntax consistent between endpoints

### DIFF
--- a/mtp_api/apps/credit/views.py
+++ b/mtp_api/apps/credit/views.py
@@ -104,7 +104,6 @@ class MultipleValueFilter(django_filters.MultipleChoiceFilter):
 
 class CreditListFilter(django_filters.FilterSet):
     status = StatusChoiceFilter(choices=CREDIT_STATUS.choices)
-    received_at = django_filters.DateFromToRangeFilter()
     user = django_filters.ModelChoiceFilter(name='owner', queryset=User.objects.all())
 
     prisoner_name = django_filters.CharFilter(name='prisoner_name', lookup_expr='icontains')
@@ -142,7 +141,8 @@ class CreditListFilter(django_filters.FilterSet):
         model = Credit
         fields = {
             'prisoner_number': ['exact'],
-            'amount': ['exact', 'lte', 'gte']
+            'amount': ['exact', 'lte', 'gte'],
+            'received_at': ['lt', 'gte'],
         }
 
 


### PR DESCRIPTION
Previously the credit endpoint used received_at_0, received_at_1 and
the transaction endpoint used received_at_gte, received_at lt. They
now both use gte/lt.