### PR TITLE
Change test check from exactly one result to existence

### DIFF
--- a/mtp_api/apps/transaction/tests/test_views.py
+++ b/mtp_api/apps/transaction/tests/test_views.py
@@ -73,9 +73,7 @@ class CreateTransactionsTestCase(
         self.assertEqual(len(data_list), Transaction.objects.count())
         for data in data_list:
             filters = filters_from_api_data(data)
-            self.assertEqual(
-                Transaction.objects.filter(**filters).count(), 1
-            )
+            self.assertTrue(Transaction.objects.filter(**filters).exists())
 
         # check logs
         self.assertEqual(


### PR DESCRIPTION
This is due to the fact that as the data is less random now
it is reasonably possible for there to be several test transactions
with the same parameters.