### PR TITLE
Avoid setting prison to null on a debit card payment

### DIFF
--- a/mtp_api/apps/credit/managers.py
+++ b/mtp_api/apps/credit/managers.py
@@ -50,8 +50,11 @@ class CreditManager(models.Manager):
             "SET prison_id = pl.prison_id, prisoner_name = pl.prisoner_name "
             "FROM credit_credit AS c LEFT OUTER JOIN prison_prisonerlocation AS pl "
             "ON c.prisoner_number = pl.prisoner_number AND c.prisoner_dob = pl.prisoner_dob "
+            "LEFT OUTER JOIN payment_payment AS p ON p.credit_id=c.id "
             "WHERE c.owner_id IS NULL AND c.resolution = 'pending' "
             "AND c.reconciled is False AND credit_credit.id = c.id "
+            # don't remove a match from a debit card payment
+            "AND NOT (pl.prison_id IS NULL AND p.uuid IS NOT NULL) "
         )
 
 

--- a/mtp_api/apps/credit/tests/test_views.py
+++ b/mtp_api/apps/credit/tests/test_views.py
@@ -1011,7 +1011,7 @@ class DateBasedPaginationTestCase(CreditListTestCase):
                 break
             self.credits = [t.credit for t in generate_transactions(
                 transaction_batch=150
-            )]
+            ) if t.credit]
         self.assertGreater(page_count, 1,
                            'Could not generate enough pages for test in %d tries' % tries)
 


### PR DESCRIPTION
As debit card refunds need to be reconciled manually, we cannot track
such refunds within our system. If an update to prisoner locations will
mean that a previously matched debit card payment will no longer be
creditable, do not update that payment's corresponding credit. Instead it
will remain assigned to the last matched prison.