### PR TITLE
Add command to delete zendesk tickets older than two weeks

### DIFF
--- a/mtp_api/apps/core/management/commands/delete_zendesk_tickets.py
+++ b/mtp_api/apps/core/management/commands/delete_zendesk_tickets.py
@@ -1,0 +1,40 @@
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.management import BaseCommand
+from django.utils import timezone
+import requests
+
+SEARCH_URL = settings.ZENDESK_BASE_URL + '/api/v2/search.json'
+DELETE_URL = settings.ZENDESK_BASE_URL + '/api/v2/tickets/destroy_many.json'
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **kwargs):
+        auth = (
+            '%s/token' % settings.ZENDESK_API_USERNAME,
+            settings.ZENDESK_API_TOKEN
+        )
+
+        query = 'type:ticket status:closed group_id:{group_id} updated<{two_weeks}'.format(
+            group_id=settings.ZENDESK_GROUP_ID,
+            two_weeks=(timezone.now() - timedelta(weeks=2)).strftime('%Y-%m-%d')
+        )
+
+        while True:
+            run_again = False
+            response = requests.get(SEARCH_URL, params={'page': 1, 'query': query},
+                                    auth=auth, timeout=15)
+
+            if response.status_code == 200:
+                data = response.json()
+                num_results = len(data['results'])
+                if num_results > 0:
+                    ids = ','.join(map(str, [r['id'] for r in data['results']]))
+                    requests.delete(DELETE_URL, params={'ids': ids},
+                                    auth=auth, timeout=15)
+                    run_again = True
+
+            if not run_again:
+                break

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -257,6 +257,11 @@ SURVEY_GIZMO_API_KEY = os.environ.get('SURVEY_GIZMO_API_KEY')
 PERFORMANCE_PLATFORM_API_URL = os.environ.get('PERFORMANCE_PLATFORM_API_URL', 'http://localhost/')
 PERFORMANCE_PLATFORM_API_TOKEN = os.environ.get('PERFORMANCE_PLATFORM_API_TOKEN', 'not_a_token')
 
+ZENDESK_BASE_URL = 'https://ministryofjustice.zendesk.com'
+ZENDESK_API_USERNAME = os.environ.get('ZENDESK_API_USERNAME', '')
+ZENDESK_API_TOKEN = os.environ.get('ZENDESK_API_TOKEN', '')
+ZENDESK_GROUP_ID = 26417927
+
 try:
     from .local import *  # noqa
 except ImportError:


### PR DESCRIPTION
We clead up older, closed tickets in order to avoid keeping
potentially personal information in zendesk longer than strictly
necessary.