### PR TITLE
Add tests and improve ISO datetime filter

### DIFF
--- a/mtp_api/apps/core/filters.py
+++ b/mtp_api/apps/core/filters.py
@@ -1,5 +1,9 @@
 from django import forms
+
+from django.utils import six
 from django.utils.dateparse import parse_datetime
+from django.utils.formats import get_format
+from django.utils.functional import lazy
 import django_filters
 
 
@@ -17,11 +21,23 @@ class StatusChoiceFilter(django_filters.ChoiceFilter):
         return qs
 
 
+def get_all_format(format_type, lang=None, use_l10n=None):
+    return ['iso8601'] + get_format(format_type, lang, use_l10n)
+
+
+get_all_format_lazy = lazy(get_all_format, six.text_type, list, tuple)
+
+
 class IsoDateTimeField(forms.DateTimeField):
+    input_formats = get_all_format_lazy('DATETIME_INPUT_FORMATS')
 
     def strptime(self, value, format):
-        datetime = parse_datetime(value)
-        return datetime or super().strptime(value, format)
+        if format == 'iso8601':
+            datetime = parse_datetime(value)
+            if datetime is None:
+                raise ValueError
+            return datetime
+        return super().strptime(value, format)
 
 
 class IsoDateTimeFilter(django_filters.DateTimeFilter):


### PR DESCRIPTION
Now only tried to parse as an ISO format datetime once,
rather than in every iteration of the parsing attempt loop.