### PR TITLE
Replace password_mismatch error message in override of user creation form

### DIFF
--- a/mtp_api/apps/mtp_auth/forms.py
+++ b/mtp_api/apps/mtp_auth/forms.py
@@ -9,6 +9,7 @@ User = get_user_model()
 class RestrictedUserCreationForm(UserCreationForm):
     error_messages = {
         'non_unique_username': _('That username already exists'),
+        'password_mismatch': _('The two password fields didn’t match'),
     }
 
     def clean_username(self):


### PR DESCRIPTION
Otherwise we get a 500 if the passwords don't match.