### PR TITLE
Downgrade concurrent scheduled command exception log to warning

### DIFF
--- a/mtp_api/apps/core/management/commands/run_scheduled_commands.py
+++ b/mtp_api/apps/core/management/commands/run_scheduled_commands.py
@@ -23,4 +23,4 @@ class Command(BaseCommand):
                         if locked_command.is_scheduled():
                             locked_command.run()
                 except DatabaseError:
-                    logger.exception('Scheduled command "%s" failed to run' % command)
+                    logger.warning('Scheduled command "%s" failed to run' % command)


### PR DESCRIPTION
It is quite likely that a command will not be run due to a database lock,
and is this not necessarily a big deal.