### PR TITLE
Add nomis integration flag to prisoner validity check

### DIFF
--- a/mtp_api/apps/prison/serializers.py
+++ b/mtp_api/apps/prison/serializers.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import transaction
 from django.utils.translation import ugettext as _
 from rest_framework import serializers
@@ -70,9 +71,17 @@ class PrisonerLocationSerializer(serializers.ModelSerializer):
 
 
 class PrisonerValiditySerializer(serializers.ModelSerializer):
+    nomis_integrated_prison = serializers.SerializerMethodField()
+
     class Meta:
         model = PrisonerLocation
         fields = (
             'prisoner_number',
             'prisoner_dob',
+            'nomis_integrated_prison'
         )
+
+    def get_nomis_integrated_prison(self, obj):
+        if settings.NOMIS_API_AVAILABLE and obj.prison.nomis_id in settings.NOMIS_API_PRISONS:
+            return True
+        return False

--- a/mtp_api/apps/prison/tests/test_views.py
+++ b/mtp_api/apps/prison/tests/test_views.py
@@ -2,6 +2,7 @@ import random
 from unittest import mock
 
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 from django.utils.dateformat import format as format_date
 from model_mommy import mommy
 from rest_framework import status
@@ -317,7 +318,11 @@ class PrisonerValidityViewTestCase(AuthTestCaseMixin, APITestCase):
             if prisoner_dob != cannot_equal:
                 return prisoner_dob
 
-    def assertValidResponse(self, response, expected_data):  # noqa
+    def assertValidResponse(self, response, valid_data):  # noqa
+        if 'nomis_integrated_prison' not in valid_data:
+            expected_data = dict(valid_data, nomis_integrated_prison=False)
+        else:
+            expected_data = valid_data
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(response_data['count'], 1)
@@ -453,6 +458,17 @@ class PrisonerValidityViewTestCase(AuthTestCaseMixin, APITestCase):
         valid_data_with_filter['prisons'] = ','.join(other_prisons.values_list('nomis_id', flat=True))
         response = self.call_authorised_endpoint(valid_data_with_filter)
         self.assertEmptyResponse(response)
+
+    @override_settings(NOMIS_API_AVAILABLE=True, NOMIS_API_PRISONS=['IXB'])
+    def test_nomis_integrated_prison_set_where_relevant(self):
+        prisoner_location = self.prisoner_locations.filter(prison__pk='IXB').first()
+        valid_data = {
+            'prisoner_number': prisoner_location.prisoner_number,
+            'prisoner_dob': format_date(prisoner_location.prisoner_dob, 'Y-m-d'),
+            'nomis_integrated_prison': True
+        }
+        response = self.call_authorised_endpoint(valid_data)
+        self.assertValidResponse(response, valid_data)
 
 
 class PrisonViewTestCase(AuthTestCaseMixin, APITestCase):

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -274,6 +274,9 @@ ZENDESK_API_USERNAME = os.environ.get('ZENDESK_API_USERNAME', '')
 ZENDESK_API_TOKEN = os.environ.get('ZENDESK_API_TOKEN', '')
 ZENDESK_GROUP_ID = 26417927
 
+NOMIS_API_AVAILABLE = os.environ.get('NOMIS_API_AVAILABLE', 'False') == 'True'
+NOMIS_API_PRISONS = os.environ.get('NOMIS_API_PRISONS', '').split(',')
+
 try:
     from .local import *  # noqa
 except ImportError:


### PR DESCRIPTION
This is to inform send-money about different behaviour that needs
to be used for prisoners who are in prisons where NOMIS integration
has been rolled out.