### PR TITLE
Ensure that date boundary in cashbook matches that of bank admin

### DIFF
--- a/mtp_api/apps/core/admin.py
+++ b/mtp_api/apps/core/admin.py
@@ -155,6 +155,22 @@ class DateRangeFilter(BaseDateFilter):
         return _('Date in range')
 
 
+class UtcDateRangeFilter(BaseDateFilter):
+
+    def get_form_fields(self):
+        return [
+            ('%s__utcdate__gte' % self.field_path, forms.DateField(
+                widget=SidebarDateWidget(attrs={'placeholder': _('Start UTC date')})
+            )),
+            ('%s__utcdate__lte' % self.field_path, forms.DateField(
+                widget=SidebarDateWidget(attrs={'placeholder': _('End UTC date')})
+            ))
+        ]
+
+    def get_submit_label(self):
+        return _('UTC date in range')
+
+
 class DateFilter(BaseDateFilter):
 
     def get_form_fields(self):

--- a/mtp_api/apps/credit/admin.py
+++ b/mtp_api/apps/credit/admin.py
@@ -7,7 +7,10 @@ from django.core.exceptions import ValidationError
 from django.db.models import Sum
 from django.utils.translation import gettext_lazy as _
 
-from core.admin import DateRangeFilter, RelatedAnyFieldListFilter, SearchFilter, add_short_description
+from core.admin import (
+    UtcDateRangeFilter, RelatedAnyFieldListFilter, SearchFilter,
+    add_short_description
+)
 from payment.models import Payment
 from transaction.models import Transaction
 from transaction.utils import format_amount
@@ -111,7 +114,7 @@ class CreditAdmin(admin.ModelAdmin):
         SourceFilter,
         'resolution',
         ('prison', RelatedAnyFieldListFilter),
-        ('received_at', DateRangeFilter),
+        ('received_at', UtcDateRangeFilter),
         'reconciled',
         'reviewed',
         ('owner__username', SearchFilter),

--- a/mtp_api/apps/credit/tests/test_views.py
+++ b/mtp_api/apps/credit/tests/test_views.py
@@ -62,9 +62,9 @@ class CreditListTestCase(
         else:
             if (logged_in_user.applicationusermapping_set.first().application.client_id ==
                     CASHBOOK_OAUTH_CLIENT_ID):
-                credits = [c for c in credits if c.received_at < timezone.make_aware(
-                    datetime.datetime.combine(timezone.now(), datetime.time.min)
-                )]
+                credits = [c for c in credits if c.received_at < datetime.datetime.combine(
+                    timezone.now().date(), datetime.time.min
+                ).replace(tzinfo=timezone.utc)]
             managing_prisons = list(PrisonUserMapping.objects.get_prison_set_for_user(logged_in_user))
             return [c for c in credits if c.prison in managing_prisons]
 

--- a/mtp_api/apps/credit/views.py
+++ b/mtp_api/apps/credit/views.py
@@ -197,8 +197,9 @@ class CreditViewMixin(object):
             return queryset
 
         if cashbook_client:
+            # must match bank admin UTC date boundary
             queryset = queryset.filter(
-                received_at__date__lt=timezone.now().date()
+                received_at__utcdate__lt=timezone.now().date()
             )
 
         return queryset.filter(


### PR DESCRIPTION
Bank admin gets credits by UTC date, as it needs to match the
batching used by Worldpay. The cashbook thus needs to display
data from dates prior to the current UTC date.