### PR TITLE
Speed up dmin page rendering by not loading massive drop downs

### DIFF
--- a/mtp_api/apps/credit/admin.py
+++ b/mtp_api/apps/credit/admin.py
@@ -53,7 +53,7 @@ class TransactionAdminInline(admin.StackedInline):
 class PaymentAdminInline(admin.StackedInline):
     model = Payment
     extra = 0
-    readonly_fields = ('uuid', 'status',)
+    readonly_fields = ('uuid', 'status', 'batch',)
 
     def has_add_permission(self, request):
         return False
@@ -108,7 +108,10 @@ class CreditAdmin(admin.ModelAdmin):
     ordering = ('-received_at',)
     date_hierarchy = 'received_at'
     inlines = (TransactionAdminInline, PaymentAdminInline, CommentAdminInline, LogAdminInline)
-    readonly_fields = ('resolution', 'reconciled', 'reviewed',)
+    readonly_fields = (
+        'resolution', 'reconciled', 'reviewed', 'blocked',
+        'sender_profile', 'prisoner_profile',
+    )
     list_filter = (
         StatusFilter,
         SourceFilter,

--- a/mtp_api/apps/payment/admin.py
+++ b/mtp_api/apps/payment/admin.py
@@ -63,7 +63,7 @@ class PaymentAdmin(admin.ModelAdmin):
     list_filter = ('status',)
     search_fields = ('uuid', 'recipient_name', 'email', 'card_number_last_digits',)
     exclude = ('credit',)
-    readonly_fields = ('credit_link',)
+    readonly_fields = ('credit_link', 'batch',)
     actions = ['display_total_amount']
 
     @add_short_description(_('credit'))


### PR DESCRIPTION
Credit and payment had drop down selections for related objects
which involved a very long list.