### PR TITLE
Make billing address read only on inline payment in credit admin

### DIFF
--- a/mtp_api/apps/credit/admin.py
+++ b/mtp_api/apps/credit/admin.py
@@ -53,7 +53,7 @@ class TransactionAdminInline(admin.StackedInline):
 class PaymentAdminInline(admin.StackedInline):
     model = Payment
     extra = 0
-    readonly_fields = ('uuid', 'status', 'batch',)
+    readonly_fields = ('uuid', 'status', 'batch', 'billing_address',)
 
     def has_add_permission(self, request):
         return False


### PR DESCRIPTION
This is to avoid slow loading and poor page performance from a
very large select drop-down.