### PR TITLE
Increase buffer size to allow for longer url params

### DIFF
--- a/api.ini
+++ b/api.ini
@@ -15,6 +15,7 @@ virtualenv = %d/venv
 module = mtp_%n.wsgi:application
 post-buffering = 1
 http-timeout = 20
+buffer-size = 65535
 
 spooler = %d/spooler
 spooler-chdir = %d


### PR DESCRIPTION
This is to allow for the longer query params used when querying
the status of a processing batch.