### PR TITLE
Allow for the generation of alternative test data for smoke tests

### DIFF
--- a/mtp_api/apps/core/forms.py
+++ b/mtp_api/apps/core/forms.py
@@ -7,7 +7,6 @@ class RecreateTestDataForm(forms.Form):
     scenario = forms.ChoiceField(
         choices=(
             ('cashbook', _('User testing the Cashbook service')),
-            ('training', _('Training data for the Cashbook service')),
             ('nomis-api-dev', _('NOMIS API dev env data')),
             ('random', _('Random set of credits')),
             ('delete-locations-credits', _('Delete prisoner location and credit data')),

--- a/mtp_api/apps/core/management/commands/load_data_listener.py
+++ b/mtp_api/apps/core/management/commands/load_data_listener.py
@@ -38,6 +38,12 @@ class Command(BaseCommand):
         if action == b'load_test_data':
             self.load_test_data(verbosity=1)
             request.sendall(b'done')
+        elif action == b'load_nomis_test_data':
+            self.load_test_data(
+                verbosity=1, prisons=['nomis-api-dev'],
+                prisoners=['nomis-api-dev'], credits='nomis'
+            )
+            request.sendall(b'done')
         elif action in (b'quit', b'exit', b'shutdown'):
             request.sendall(b'shutting down')
             threading.Timer(1, self.shutdown).start()
@@ -45,8 +51,11 @@ class Command(BaseCommand):
             request.sendall(b'unknown action')
 
     @synchronised
-    def load_test_data(self, verbosity=1):
-        call_command('load_test_data', protect_superusers=True, verbosity=verbosity)
+    def load_test_data(self, verbosity=1, **kwargs):
+        call_command(
+            'load_test_data', protect_superusers=True,
+            verbosity=verbosity, **kwargs
+        )
 
     @synchronised
     def shutdown(self):

--- a/mtp_api/apps/core/views.py
+++ b/mtp_api/apps/core/views.py
@@ -155,12 +155,6 @@ class RecreateTestDataView(AdminViewMixin, FormView):
             elif scenario == 'cashbook':
                 options.update({
                     'prisons': ['nomis'],
-                    'prisoners': ['nomis'],
-                    'credits': 'nomis',
-                })
-            elif scenario == 'training':
-                options.update({
-                    'prisons': ['nomis'],
                     'prisoners': ['sample'],
                     'credits': 'nomis',
                 })

--- a/mtp_api/apps/transaction/tests/utils.py
+++ b/mtp_api/apps/transaction/tests/utils.py
@@ -202,7 +202,7 @@ def generate_predetermined_transactions_data():
         'created': over_a_week_ago,
         'modified': a_week_ago,
         'owner': None,
-        'credited': True,
+        'credited': False,
         'refunded': False,
 
         'sender_name': 'Mary Stevenson',


### PR DESCRIPTION
Cashbook smoke tests rely on the generation of dev NOMIS compatible
prisoner locations. Also remove no longer relevant test data scenarios.