### PR TITLE
Change password reset with code to send the email on the API side

### DIFF
--- a/mtp_api/apps/mtp_auth/serializers.py
+++ b/mtp_api/apps/mtp_auth/serializers.py
@@ -203,9 +203,14 @@ class ChangePasswordSerializer(serializers.Serializer):
     new_password = serializers.CharField()
 
 
+class CreateNewPasswordSerializer(serializers.Serializer):
+    password_change_url = serializers.CharField()
+    reset_code_param = serializers.CharField()
+
+
 class ResetPasswordSerializer(serializers.Serializer):
     username = serializers.CharField(write_only=True)
-    create_email_code = serializers.BooleanField(required=False)
+    create_password = CreateNewPasswordSerializer(required=False)
 
 
 class ChangePasswordWithCodeSerializer(serializers.Serializer):

--- a/mtp_api/templates/mtp_auth/create_new_password.html
+++ b/mtp_api/templates/mtp_auth/create_new_password.html
@@ -1,0 +1,13 @@
+{% extends 'mtp_common/email_base.html' %}
+{% load i18n %}
+
+{% block inner_content %}
+  <p>
+    {% trans 'Click on the link below to create your new Prisoner Money password.' %}
+  </p>
+
+  <p>
+    <a href="{{ change_password_url }}">{{ change_password_url }}</a>
+  </p>
+
+{% endblock %}

--- a/mtp_api/templates/mtp_auth/create_new_password.txt
+++ b/mtp_api/templates/mtp_auth/create_new_password.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% trans 'Copy and paste the link below into your browser address bar to create your new Prisoner Money password.' %}
+
+{{ change_password_url }}


### PR DESCRIPTION
If the client app were to send the email, there would need to be an
unauthenticated endpoint to retrieve a user's email address, which
would be bad.

Adds new fields to the request to specify the URL format of the
client app's password reset page.