### PR TITLE
Catch errors for scheduled commands

### DIFF
--- a/mtp_api/apps/core/management/commands/run_scheduled_commands.py
+++ b/mtp_api/apps/core/management/commands/run_scheduled_commands.py
@@ -23,4 +23,8 @@ class Command(BaseCommand):
                         if locked_command.is_scheduled():
                             locked_command.run()
                 except DatabaseError:
-                    logger.warning('Scheduled command "%s" failed to run' % command)
+                    logger.warning(
+                        'Scheduled command "%s" failed to run due to database error' % command
+                    )
+                except Exception:
+                    logger.exception('Scheduled command "%s" failed to run' % command)


### PR DESCRIPTION
This will prevent a failing scheduled command from stopping others
to run.