### PR TITLE
Set a public static url for assets in places that cannot access the API

### DIFF
--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -6,6 +6,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 import os
 import sys
+from urllib.parse import urljoin
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(BASE_DIR, 'apps'))
@@ -118,6 +119,10 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'assets'),
     os.path.join(BASE_DIR, 'assets-static'),
 ]
+
+PUBLIC_STATIC_URL = os.environ.get(
+    'PUBLIC_STATIC_URL', urljoin(SITE_URL, STATIC_URL)
+)
 
 TEMPLATES = [
     {

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=7.8,<7.9
+money-to-prisoners-common[testing]>=8.1,<8.2

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place your docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=7.8,<7.9
+money-to-prisoners-common[monitoring]>=8.1,<8.2
 
 uWSGI==2.0.17


### PR DESCRIPTION
As the API is unavailable from the public internet, assets in e.g. emails
sent by the API were not available.