### PR TITLE
Generate disbursement invoice number on confirmation as sent is too late

### DIFF
--- a/mtp_api/apps/disbursement/managers.py
+++ b/mtp_api/apps/disbursement/managers.py
@@ -61,7 +61,7 @@ class DisbursementManager(models.Manager):
         elif resolution == DISBURSEMENT_RESOLUTION.SENT:
             Log.objects.disbursements_sent(to_update, user)
 
-        if resolution == DISBURSEMENT_RESOLUTION.SENT:
+        if resolution == DISBURSEMENT_RESOLUTION.CONFIRMED:
             to_update.update(
                 resolution=resolution,
                 invoice_number=Concat(

--- a/mtp_api/apps/disbursement/models.py
+++ b/mtp_api/apps/disbursement/models.py
@@ -124,6 +124,7 @@ class Disbursement(TimeStampedModel):
         self.resolution = DISBURSEMENT_RESOLUTION.CONFIRMED
         if nomis_transaction_id:
             self.nomis_transaction_id = nomis_transaction_id
+        self.invoice_number = self._generate_invoice_number()
         self.save()
         disbursement_confirmed.send(
             sender=Disbursement, disbursement=self, by_user=by_user)
@@ -134,7 +135,6 @@ class Disbursement(TimeStampedModel):
         if not self.resolution_permitted(DISBURSEMENT_RESOLUTION.SENT):
             raise InvalidDisbursementStateException([self.id])
         self.resolution = DISBURSEMENT_RESOLUTION.SENT
-        self.invoice_number = self._generate_invoice_number()
         self.save()
         disbursement_sent.send(
             sender=Disbursement, disbursement=self, by_user=by_user)

--- a/mtp_api/apps/disbursement/tests/test_views.py
+++ b/mtp_api/apps/disbursement/tests/test_views.py
@@ -470,6 +470,8 @@ class UpdateDisbursementResolutionTestCase(AuthTestCaseMixin, APITestCase):
             resolution=DISBURSEMENT_RESOLUTION.PRECONFIRMED
         )
 
+        self.assertEqual(disbursement.invoice_number, None)
+
         response = self.client.post(
             reverse('disbursement-confirm'), format='json',
             data=[{'id': disbursement.id, 'nomis_transaction_id': '1112-1'}],
@@ -486,6 +488,10 @@ class UpdateDisbursementResolutionTestCase(AuthTestCaseMixin, APITestCase):
         self.assertEqual(
             confirmed_disbursement.nomis_transaction_id,
             '1112-1'
+        )
+        self.assertEqual(
+            confirmed_disbursement.invoice_number,
+            confirmed_disbursement._generate_invoice_number()
         )
 
         logs = Log.objects.all()
@@ -556,8 +562,6 @@ class UpdateDisbursementResolutionTestCase(AuthTestCaseMixin, APITestCase):
         self.assertEqual(disbursements.count(), 2)
         self.assertEqual(disbursements[0].resolution, DISBURSEMENT_RESOLUTION.SENT)
         self.assertEqual(disbursements[1].resolution, DISBURSEMENT_RESOLUTION.SENT)
-        self.assertEqual(disbursements[0].invoice_number, disbursement1._generate_invoice_number())
-        self.assertEqual(disbursements[1].invoice_number, disbursement2._generate_invoice_number())
 
         logs = Log.objects.all()
         self.assertEqual(logs[0].disbursement, disbursements[0])

--- a/mtp_api/apps/disbursement/tests/utils.py
+++ b/mtp_api/apps/disbursement/tests/utils.py
@@ -144,7 +144,7 @@ def setup_disbursement(end_date, disbursement_counter, data):
 
     with MockModelTimestamps(data['created'], data['modified']):
         new_disbursement = Disbursement.objects.create(**data)
-        if new_disbursement.resolution == DISBURSEMENT_RESOLUTION.SENT:
+        if new_disbursement.resolution == DISBURSEMENT_RESOLUTION.CONFIRMED:
             new_disbursement.invoice_number = new_disbursement._generate_invoice_number()
             new_disbursement.save()
 


### PR DESCRIPTION
If we do not generate the invoice number until the disbursement is sent
it is not available for inclusion in the disbursements file.