### PR TITLE
Set profile fields to read-only on disbursement admin page

### DIFF
--- a/mtp_api/apps/disbursement/admin.py
+++ b/mtp_api/apps/disbursement/admin.py
@@ -44,6 +44,7 @@ class DisbursementAdmin(admin.ModelAdmin):
     inlines = (LogAdminInline, CommentAdminInline,)
     date_hierarchy = 'created'
     actions = ['display_total_amount']
+    readonly_fields = ('recipient_profile', 'prisoner_profile',)
 
     @add_short_description(_('amount'))
     def formatted_amount(self, instance):


### PR DESCRIPTION
This is to avoid lengthy load times when viewing these pages.