### PR TITLE
Ensure disbursement-only bank admins can download disbursements file

### DIFF
--- a/mtp_api/apps/mtp_auth/fixtures/initial_groups.json
+++ b/mtp_api/apps/mtp_auth/fixtures/initial_groups.json
@@ -111,7 +111,9 @@
     "permissions": [
       ["view_disbursement", "disbursement", "disbursement"],
       ["change_disbursement", "disbursement", "disbursement"],
-      ["add_filedownload", "core", "filedownload"]
+      ["add_filedownload", "core", "filedownload"],
+      ["view_privateestatebatch", "credit", "privateestatebatch"],
+      ["patch_processed_transaction", "transaction", "transaction"]
     ]
   }
 }


### PR DESCRIPTION
…they too need to reconcile and load private estate batches