### PR TITLE
Prevent the creation of empty payment batches due to race condition

### DIFF
--- a/mtp_api/apps/payment/managers.py
+++ b/mtp_api/apps/payment/managers.py
@@ -22,7 +22,8 @@ class PaymentManager(models.Manager):
             credit__reconciled=False
         ).select_for_update()
 
-        if update_set.count() > 0:
+        # use `len` as `select` is needed to acquire lock
+        if len(update_set):
             from .models import Batch
             max_ref_code = Batch.objects.all().aggregate(models.Max('ref_code'))['ref_code__max']
             if max_ref_code:


### PR DESCRIPTION
When reconciling payments, a payment batch object is created and
all payments in the batch are assigned to it. We use select_for_update
on the set of payments that will comprise this batch in order to
avoid interleaving operations, however as we did not evaluate the
queryset before creating the payment batch, this was resulting in new
payment batches being created which then didn't have any payments in.

By changing the conditional from a `count()` to a `len()` this ensures
that the update set is evaluated and a lock acquired before the payment
batch record is created, which should avoid superfluous payment batches
being made.