### PR TITLE
Rename senders search param to simple_search

### DIFF
--- a/mtp_api/apps/security/tests/test_views.py
+++ b/mtp_api/apps/security/tests/test_views.py
@@ -64,9 +64,9 @@ class SenderProfileListTestCase(SecurityViewTestCase):
     def _get_url(self, *args, **kwargs):
         return reverse('senderprofile-list')
 
-    def test_search_by_search_param(self):
+    def test_search_by_simple_search_param(self):
         """
-        Test for when the search param `search` is used.
+        Test for when the search param `simple_search` is used.
 
         Checks that the API returns the senders with the supplied search value in
             the sender name of a transfer bank details object
@@ -124,7 +124,7 @@ class SenderProfileListTestCase(SecurityViewTestCase):
 
         response_data = self._get_list(
             self._get_authorised_user(),
-            search=term,
+            simple_search=term,
         )['results']
 
         self.assertEqual(len(response_data), 3)

--- a/mtp_api/apps/security/views.py
+++ b/mtp_api/apps/security/views.py
@@ -70,7 +70,7 @@ class MonitorProfileMixin(viewsets.GenericViewSet):
 
 
 class SenderProfileListFilter(django_filters.FilterSet):
-    search = SplitTextInMultipleFieldsFilter(
+    simple_search = SplitTextInMultipleFieldsFilter(
         field_names=(
             'bank_transfer_details__sender_name',
             'debit_card_details__cardholder_name__name',


### PR DESCRIPTION
Credits uses already a `search` param which acts a bit differently to what we need here.

This renames the senders `search` param to `simple_search` so that we can use that name consistently for all object types.