### PR TITLE
Add simple_search search param to credit list view

### DIFF
--- a/mtp_api/apps/credit/tests/test_views.py
+++ b/mtp_api/apps/credit/tests/test_views.py
@@ -616,6 +616,81 @@ class CreditListWithSearchTestCase(CreditListTestCase):
         self.assertFalse(response.data['results'])
 
 
+class CreditListWithSimpleSearchTestCase(CreditListTestCase):
+    def test_search(self):
+        """
+        Test for when the search param `simple_search` is used.
+
+        Checks that the API return the credits with the supplied search value in
+            the sender name of a transaction object
+            OR
+            the cardholder name of a payment object
+            OR
+            the email address of a payment object
+            OR
+            the prisoner number
+        """
+        # prepare the data
+        managed_prison_credits = self._get_managed_prison_credits()
+        managed_prison_credits_ids = [credit.id for credit in managed_prison_credits]
+
+        # change the loaded data so that the test matches exactly 3 records
+        term_part1 = get_random_string(10)
+        term_part2 = get_random_string(10)
+        term = f'{term_part1} {term_part2}'
+
+        credit_with_transaction = Credit.objects.filter(
+            transaction__isnull=False,
+            payment__isnull=True,
+            id__in=managed_prison_credits_ids,
+        ).order_by('?').first()
+        credit_with_transaction.transaction.sender_name = f'{term}Junior'.upper()
+        credit_with_transaction.transaction.save()
+
+        credits_with_payment = list(
+            Credit.objects.filter(
+                transaction__isnull=True,
+                payment__isnull=False,
+                id__in=managed_prison_credits_ids,
+            ).order_by('?')[:3]
+        )
+        credits_with_payment[0].payment.cardholder_name = f'Mr{term_part1}an {term_part2}'
+        credits_with_payment[0].payment.save()
+
+        credits_with_payment[1].prisoner_number = term_part1
+        credits_with_payment[1].payment.email = f'{term_part2}@example.com'
+        credits_with_payment[1].save()
+        credits_with_payment[1].payment.save()
+
+        # this should not be matched as only term_part1 is present
+        credits_with_payment[2].prisoner_number = term_part1
+        credits_with_payment[2].save()
+
+        # run the test
+        logged_in_user = self._get_authorised_user()
+
+        url = self._get_url(
+            **{
+                'simple_search': term,
+            },
+        )
+        response = self.client.get(
+            url, format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(logged_in_user),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.data['results']
+        self.assertEqual(len(response_data), 3)
+        self.assertEqual(
+            {item['id'] for item in response_data},
+            {
+                credit_with_transaction.id,
+                credits_with_payment[0].id,
+                credits_with_payment[1].id,
+            },
+        )
+
+
 class CreditListInvalidValuesTestCase(CreditListTestCase):
 
     def test_invalid_status_filter(self):

--- a/mtp_api/apps/credit/views.py
+++ b/mtp_api/apps/credit/views.py
@@ -13,9 +13,14 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from core.filters import (
-    BlankStringFilter, StatusChoiceFilter, IsoDateTimeFilter,
-    MultipleFieldCharFilter, SafeOrderingFilter, MultipleValueFilter,
-    annotate_filter
+    annotate_filter,
+    BlankStringFilter,
+    IsoDateTimeFilter,
+    MultipleFieldCharFilter,
+    MultipleValueFilter,
+    SafeOrderingFilter,
+    SplitTextInMultipleFieldsFilter,
+    StatusChoiceFilter,
 )
 from core.models import TruncUtcDate
 from core.permissions import ActionsBasedPermissions
@@ -149,6 +154,15 @@ class CreditListFilter(django_filters.FilterSet):
     prison_category = MultipleValueFilter(field_name='prison__categories__name')
     prison_population = MultipleValueFilter(field_name='prison__populations__name')
 
+    simple_search = SplitTextInMultipleFieldsFilter(
+        field_names=(
+            'transaction__sender_name',
+            'payment__cardholder_name',
+            'payment__email',
+            'prisoner_number',
+        ),
+        lookup_expr='icontains',
+    )
     search = CreditTextSearchFilter()
     sender_name = MultipleFieldCharFilter(
         field_name=('transaction__sender_name', 'payment__cardholder_name',),


### PR DESCRIPTION
This adds a new `simple_search` search param to the credit list view which makes an icontains lookup on multiple text fields.
It's different from the `search` field which is more sophisticated and searches across more fields of different types.

@ushkarev I've decided not to parse the prisoner_number as I don't think the change in performance is big enough to justify the added complexity. Even if the text inputted by the user matches a prisoner number, we would still need to run ICONTAINS in OR on the other fields in case the same text appears in other places. Therefore, we would only save one ICONTAINS (which would be replaced by an IEXACT) which is minimal in my opinion.