### PR TITLE
Use PostcodeFilter in disbursements filtering

### DIFF
--- a/mtp_api/apps/core/filters.py
+++ b/mtp_api/apps/core/filters.py
@@ -1,3 +1,4 @@
+import re
 from functools import reduce
 from operator import or_
 
@@ -156,3 +157,23 @@ def annotate_filter(filter_, annotations):
 
     filter_.filter = annotated_filter
     return filter_
+
+
+class PostcodeFilter(django_filters.CharFilter):
+    """
+    Filters by postcode. It supports whitespaces, lower/uppercases etc.
+    """
+    def __init__(self, **kwargs):
+        if 'lookup_expr' in kwargs:
+            raise ValueError('You cannot override the default lookup_expr.')
+
+        kwargs['lookup_expr'] = 'iregex'
+        super().__init__(**kwargs)
+
+    def filter(self, qs, value):
+        if value in EMPTY_VALUES:
+            return qs
+
+        value = re.sub(r'[^0-9A-Za-z]+', '', value)
+        value = r'\s*'.join(value)
+        return super().filter(qs, value)

--- a/mtp_api/apps/credit/views.py
+++ b/mtp_api/apps/credit/views.py
@@ -18,6 +18,7 @@ from core.filters import (
     IsoDateTimeFilter,
     MultipleFieldCharFilter,
     MultipleValueFilter,
+    PostcodeFilter,
     SafeOrderingFilter,
     SplitTextInMultipleFieldsFilter,
     StatusChoiceFilter,
@@ -128,17 +129,6 @@ class CreditSourceFilter(django_filters.ChoiceFilter):
         elif value == CREDIT_SOURCE.UNKNOWN:
             qs = qs.filter(payment__isnull=True, transaction__isnull=True)
         return qs
-
-
-class PostcodeFilter(django_filters.CharFilter):
-    def __init__(self, **kwargs):
-        kwargs['lookup_expr'] = 'iregex'
-        super().__init__(**kwargs)
-
-    def filter(self, qs, value):
-        value = re.sub(r'[^0-9A-Za-z]+', '', value)
-        value = r'\s*'.join(value)
-        return super().filter(qs, value)
 
 
 class MonitoredProfileFilter(django_filters.BooleanFilter):

--- a/mtp_api/apps/disbursement/views.py
+++ b/mtp_api/apps/disbursement/views.py
@@ -10,6 +10,7 @@ from core.filters import (
     annotate_filter,
     IsoDateTimeFilter,
     MultipleValueFilter,
+    PostcodeFilter,
     SafeOrderingFilter,
     SplitTextInMultipleFieldsFilter,
 )
@@ -83,7 +84,7 @@ class DisbursementFilter(django_filters.FilterSet):
     recipient_email = django_filters.CharFilter(field_name='recipient_email', lookup_expr='icontains')
 
     city = django_filters.CharFilter(field_name='city', lookup_expr='iexact')
-    postcode = django_filters.CharFilter(field_name='postcode', lookup_expr='icontains')
+    postcode = PostcodeFilter(field_name='postcode')
 
     sort_code = django_filters.CharFilter(field_name='sort_code')
     account_number = django_filters.CharFilter(field_name='account_number')


### PR DESCRIPTION
This:
- moves PostcodeFilter to core app
- adds tests for PostcodeFilter
- replaces disbursements postcode filter field with PostcodeFilter
- refactor disbursements tests so that they test more scenarios and further scenarios can be easily added