### PR TITLE
Prison filter in advanced search

### DIFF
--- a/mtp_api/apps/security/serializers.py
+++ b/mtp_api/apps/security/serializers.py
@@ -50,7 +50,22 @@ class DebitCardSenderDetailsSerializer(serializers.ModelSerializer):
         return list(obj.sender_emails.values_list('email', flat=True))
 
 
+class PrisonSerializer(serializers.ModelSerializer):
+    """
+    Serializer for nested prison fields.
+    """
+
+    class Meta:
+        model = Prison
+        fields = (
+            'nomis_id',
+            'name',
+        )
+
+
 class SenderProfileSerializer(serializers.ModelSerializer):
+    prisons = PrisonSerializer(many=True)
+
     bank_transfer_details = BankTransferSenderDetailsSerializer(many=True)
     debit_card_details = DebitCardSenderDetailsSerializer(many=True)
 
@@ -65,6 +80,7 @@ class SenderProfileSerializer(serializers.ModelSerializer):
             'id',
             'credit_count',
             'credit_total',
+            'prisons',
             'prisoner_count',
             'prison_count',
             'bank_transfer_details',
@@ -72,15 +88,6 @@ class SenderProfileSerializer(serializers.ModelSerializer):
             'created',
             'modified',
             'monitoring',
-        )
-
-
-class PrisonSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Prison
-        fields = (
-            'nomis_id',
-            'name',
         )
 
 

--- a/mtp_api/apps/security/tests/test_views.py
+++ b/mtp_api/apps/security/tests/test_views.py
@@ -459,6 +459,56 @@ class PrisonerProfileListTestCase(SecurityViewTestCase):
             greater_than_3_count, len(data)
         )
 
+    def test_filter_by_current_prison(self):
+        """
+        Test filtering prisoners by current prison as single value.
+        """
+        prison_id = 'IXB'
+        response = self._get_list(
+            self._get_authorised_user(),
+            current_prison=prison_id,
+        )
+        actual_results = response['results']
+
+        actual_prisoner_profiles = PrisonerProfile.objects.filter(
+            current_prison__nomis_id=prison_id,
+        ).distinct()
+
+        self.assertTrue(actual_results)
+        self.assertEqual(
+            len(actual_results),
+            actual_prisoner_profiles.count(),
+        )
+        self.assertCountEqual(
+            actual_prisoner_profiles.values_list('id', flat=True),
+            [profile['id'] for profile in actual_results],
+        )
+
+    def test_filter_by_list_of_current_prisons(self):
+        """
+        Test filtering prisoners by current prison as multi value.
+        """
+        prison_ids = ['IXB', 'INP']
+        response = self._get_list(
+            self._get_authorised_user(),
+            current_prison=prison_ids,
+        )
+        actual_results = response['results']
+
+        actual_prisoner_profiles = PrisonerProfile.objects.filter(
+            current_prison__nomis_id__in=prison_ids,
+        ).distinct()
+
+        self.assertTrue(actual_results)
+        self.assertEqual(
+            len(actual_results),
+            actual_prisoner_profiles.count(),
+        )
+        self.assertCountEqual(
+            actual_prisoner_profiles.values_list('id', flat=True),
+            [profile['id'] for profile in actual_results],
+        )
+
     def test_filter_by_monitoring(self):
         user = self._get_authorised_user()
 

--- a/mtp_api/apps/security/views.py
+++ b/mtp_api/apps/security/views.py
@@ -219,6 +219,9 @@ class PrisonerProfileListFilter(django_filters.FilterSet):
         name='prisoner_name', lookup_expr='icontains'
     )
 
+    current_prison = django_filters.ModelMultipleChoiceFilter(
+        queryset=Prison.objects.all(),
+    )
     prison = django_filters.ModelMultipleChoiceFilter(
         name='prisons', queryset=Prison.objects.all()
     )


### PR DESCRIPTION
This:
1. Adds `prisons` to `GET /senders/` response
2. Adds a new `current_prison` filter to the `GET /prisoners/` endpoint so that clients can filter by one or more values.