### PR TITLE
Add GA campaign settings to notification emails

### DIFF
--- a/mtp_api/apps/notification/management/commands/send_notification_emails.py
+++ b/mtp_api/apps/notification/management/commands/send_notification_emails.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from django.conf import settings
 from django.core.management import BaseCommand
 from django.utils.translation import gettext_lazy as _
@@ -19,7 +21,13 @@ class Command(BaseCommand):
         period_start, period_end = get_notification_period(frequency)
         events = get_events(period_start, period_end)
 
+        campaign_qs = urlencode({
+            'utm_source': 'notifications',
+            'utm_medium': 'email',
+            'utm_campaign': 'notifications',
+        })
         base_email_context = {
+            'campaign_qs': campaign_qs,
             'period_start': period_start,
             'notifications_url': (
                 f'{settings.NOMS_OPS_URL}/security/notifications/#date-{period_start.date().isoformat()}'

--- a/mtp_api/templates/notification/not-monitoring.html
+++ b/mtp_api/templates/notification/not-monitoring.html
@@ -29,13 +29,13 @@
 
   <p>
     {% blocktrans trimmed %}
-      You can turn off these email notifications from your <a href="{{ settings_url }}">settings screen</a> in the intelligence tool.
+      You can turn off these email notifications from your <a href="{{ settings_url }}?{{ campaign_qs }}">settings screen</a> in the intelligence tool.
     {% endblocktrans %}
   </p>
 
   <p>
     {% blocktrans trimmed %}
-      Any <a href="{{ feedback_url }}">feedback</a> you can give us helps improve the tool further.
+      Any <a href="{{ feedback_url }}?{{ campaign_qs }}">feedback</a> you can give us helps improve the tool further.
     {% endblocktrans %}
   </p>
 

--- a/mtp_api/templates/notification/not-monitoring.txt
+++ b/mtp_api/templates/notification/not-monitoring.txt
@@ -12,10 +12,10 @@
 {% trans 'When there is no new activity on what you’re monitoring, we won’t email you.' %}
 
 {% trans 'You can turn off these email notifications from your settings screen in the intelligence tool.' %}
-{{ settings_url }}
+{{ settings_url }}?{{ campaign_qs }}
 
 {% trans 'Any feedback you can give us helps improve the tool further.' %}
-{{ feedback_url }}
+{{ feedback_url }}?{{ campaign_qs }}
 
 {% trans 'We hope you find this helpful.' %}
 

--- a/mtp_api/templates/notification/notifications.html
+++ b/mtp_api/templates/notification/notifications.html
@@ -19,7 +19,7 @@
   {% endblock %}
 
   <h2 style="padding:0;font-size:24px;line-height:35px;font-weight:bold">
-    <a href="{{ notifications_url }}" style="color:#005ea5">
+    <a href="{{ notifications_url }}?{{ campaign_qs }}" style="color:#005ea5">
       {% blocktrans trimmed count count=event_group.transaction_count %}
         You have {{ count }} notification
       {% plural %}
@@ -32,7 +32,7 @@
     <h3 style="padding:0;font-size:19px;line-height:25px;font-weight:bold">{% trans 'Payment sources' %}</h3>
 
     {% for profile in event_group.senders %}
-      <a href="{{ sender_url }}{{ profile.id }}/" style="color:#005ea5">
+      <a href="{{ sender_url }}{{ profile.id }}/?{{ campaign_qs }}" style="color:#005ea5">
         {{ profile.description }}
         –
         {% blocktrans trimmed count count=profile.transaction_count %}
@@ -49,7 +49,7 @@
     <h3 style="padding:0;font-size:19px;line-height:25px;font-weight:bold">{% trans 'Prisoners' %}</h3>
 
     {% for profile in event_group.prisoners %}
-      <a href="{{ prisoner_url }}{{ profile.id }}/{% if profile.disbursements_only %}disbursements/{% endif %}" style="color:#005ea5">
+      <a href="{{ prisoner_url }}{{ profile.id }}/{% if profile.disbursements_only %}disbursements/{% endif %}?{{ campaign_qs }}" style="color:#005ea5">
         {{ profile.description }}
         –
         {% blocktrans trimmed count count=profile.transaction_count %}
@@ -64,13 +64,13 @@
 
   <p>
     {% blocktrans trimmed %}
-      You can turn off these email notifications from your <a href="{{ settings_url }}">settings screen</a> in the intelligence tool.
+      You can turn off these email notifications from your <a href="{{ settings_url }}?{{ campaign_qs }}">settings screen</a> in the intelligence tool.
     {% endblocktrans %}
   </p>
 
   <p>
     {% blocktrans trimmed %}
-      Any <a href="{{ feedback_url }}">feedback</a> you can give us helps improve the tool further.
+      Any <a href="{{ feedback_url }}?{{ campaign_qs }}">feedback</a> you can give us helps improve the tool further.
     {% endblocktrans %}
   </p>
 

--- a/mtp_api/templates/notification/notifications.txt
+++ b/mtp_api/templates/notification/notifications.txt
@@ -5,7 +5,7 @@
 {% block preamble %}{% blocktrans trimmed with date=period_start|date:'d/m/Y' %}Here are your notifications for payment sources or prisoners you’re monitoring for {{ date }}.{% endblocktrans %}{% endblock %}
 
 {% blocktrans trimmed count count=event_group.transaction_count %}You have {{ count }} notification{% plural %}You have {{ count }} notifications{% endblocktrans %}
-{{ notifications_url }}
+{{ notifications_url }}?{{ campaign_qs }}
 
 {% if event_group.senders %}* {% trans 'Payment sources' %} *
 {% for profile in event_group.senders %}{{ profile.description }} – {% blocktrans trimmed count count=profile.transaction_count %}{{ count }} transaction{% plural %}{{ count }} transactions{% endblocktrans %}
@@ -14,10 +14,10 @@
 {% for profile in event_group.prisoners %}{{ profile.description }} – {% blocktrans trimmed count count=profile.transaction_count %}{{ count }} transaction{% plural %}{{ count }} transactions{% endblocktrans %}
 {% endfor %}{% endif %}
 {% trans 'You can turn off these email notifications from your settings screen in the intelligence tool.' %}
-{{ settings_url }}
+{{ settings_url }}?{{ campaign_qs }}
 
 {% trans 'Any feedback you can give us helps improve the tool further.' %}
-{{ feedback_url }}
+{{ feedback_url }}?{{ campaign_qs }}
 
 {% trans 'Kind regards' %},
 {% trans 'Prisoner money team' %}


### PR DESCRIPTION
This adds GA campaign settings to notification emails.

It depends on https://github.com/ministryofjustice/money-to-prisoners-common/pull/356.
Also, the noms-ops application needs the version of mtp-common with the change in PR 356.