### PR TITLE
Show counts for matching counting rules in notification report

### DIFF
--- a/mtp_api/apps/notification/management/commands/send_notification_report.py
+++ b/mtp_api/apps/notification/management/commands/send_notification_report.py
@@ -18,7 +18,7 @@ from credit.constants import CREDIT_STATUS
 from credit.models import Credit, LOG_ACTIONS as CREDIT_LOG_ACTIONS
 from disbursement.constants import DISBURSEMENT_METHOD, DISBURSEMENT_RESOLUTION
 from disbursement.models import Disbursement, LOG_ACTIONS as DISBURSEMENT_LOG_ACTIONS
-from notification.rules import RULES, MonitoredRule
+from notification.rules import RULES, MonitoredRule, Triggered
 from transaction.utils import format_amount
 
 
@@ -134,13 +134,17 @@ def generate_sheet(worksheet, serialiser, rule, record_set):
     worksheet.append(headers)
     count = 0
     for record in record_set:
-        if rule.applies_to(record) and rule.triggered(record):
-            row = serialiser.serialise(worksheet, record)
-            worksheet.append([
-                row.get(field, None)
-                for field in headers
-            ])
-            count += 1
+        if not rule.applies_to(record):
+            continue
+        triggered = rule.triggered(record)
+        if not triggered:
+            continue
+        row = serialiser.serialise(worksheet, record, triggered)
+        worksheet.append([
+            row.get(field, None)
+            for field in headers
+        ])
+        count += 1
     if count:
         worksheet.auto_filter.ref = f'A1:{get_column_letter(len(headers))}{count + 1}'
     else:
@@ -194,7 +198,7 @@ class Serialiser:
             headers.insert(1, 'Monitored by')
         return headers
 
-    def serialise(self, worksheet, record):
+    def serialise(self, worksheet, record, triggered: Triggered):
         linked_cell = WriteOnlyCell(worksheet, self.get_internal_id(record))
         linked_cell.hyperlink = self.get_noms_ops_url(record)
         linked_cell.style = 'Hyperlink'
@@ -203,7 +207,7 @@ class Serialiser:
             'Internal ID': linked_cell,
         }
         if self.is_monitored_rule:
-            row['Monitored by'] = self.rule.get_event_trigger(record).get_monitoring_users().count()
+            row['Monitored by'] = triggered.kwargs['monitoring_user_count']
         return row
 
     def get_internal_id(self, record):
@@ -227,8 +231,8 @@ class CreditSerialiser(Serialiser, serialised_model=Credit):
             'NOMIS transaction',
         ]
 
-    def serialise(self, worksheet, record: Credit):
-        row = super().serialise(worksheet, record)
+    def serialise(self, worksheet, record: Credit, triggered: Triggered):
+        row = super().serialise(worksheet, record, triggered)
         status = record.status
         if status:
             status = str(CREDIT_STATUS.for_value(status).display)
@@ -295,8 +299,8 @@ class DisbursementSerialiser(Serialiser, serialised_model=Disbursement):
             'NOMIS transaction', 'SOP invoice number',
         ]
 
-    def serialise(self, worksheet, record: Disbursement):
-        row = super().serialise(worksheet, record)
+    def serialise(self, worksheet, record: Disbursement, triggered: Triggered):
+        row = super().serialise(worksheet, record, triggered)
         row.update({
             'Date entered': local_datetime_for_xlsx(record.created),
             'Date confirmed': local_datetime_for_xlsx(find_log_date(record, DISBURSEMENT_LOG_ACTIONS.CONFIRMED)),

--- a/mtp_api/apps/notification/tests/test_rules.py
+++ b/mtp_api/apps/notification/tests/test_rules.py
@@ -97,12 +97,16 @@ class RuleTestCase(TestCase):
             disbursement.save()
 
         for credit in credits:
-            self.assertTrue(RULES['NWN'].triggered(credit))
+            triggered = RULES['NWN'].triggered(credit)
+            self.assertTrue(triggered)
+            self.assertEqual(triggered.kwargs['amount'], credit.amount)
             events = RULES['NWN'].create_events(credit)
             self.assertEventMatchesRecord(events, credit)
         self.assertEqual(Event.objects.count(), 10)
         for disbursement in disbursements:
-            self.assertTrue(RULES['NWN'].triggered(disbursement))
+            triggered = RULES['NWN'].triggered(disbursement)
+            self.assertTrue(triggered)
+            self.assertEqual(triggered.kwargs['amount'], disbursement.amount)
             events = RULES['NWN'].create_events(disbursement)
             self.assertEventMatchesRecord(events, disbursement)
         self.assertEqual(Event.objects.count(), 20)
@@ -110,9 +114,13 @@ class RuleTestCase(TestCase):
         credits = Credit.objects.filter(amount__endswith='00')
         disbursements = Disbursement.objects.filter(amount__endswith='00')
         for credit in credits:
-            self.assertFalse(RULES['NWN'].triggered(credit))
+            triggered = RULES['NWN'].triggered(credit)
+            self.assertFalse(triggered)
+            self.assertEqual(triggered.kwargs['amount'], credit.amount)
         for disbursement in disbursements:
-            self.assertFalse(RULES['NWN'].triggered(disbursement))
+            triggered = RULES['NWN'].triggered(disbursement)
+            self.assertFalse(triggered)
+            self.assertEqual(triggered.kwargs['amount'], disbursement.amount)
         self.assertEqual(Event.objects.count(), 20)
 
     def test_create_events_for_ha(self):
@@ -126,12 +134,16 @@ class RuleTestCase(TestCase):
             disbursement.save()
 
         for credit in credits:
-            self.assertTrue(RULES['HA'].triggered(credit))
+            triggered = RULES['HA'].triggered(credit)
+            self.assertTrue(triggered)
+            self.assertEqual(triggered.kwargs['amount'], credit.amount)
             events = RULES['HA'].create_events(credit)
             self.assertEventMatchesRecord(events, credit)
         self.assertEqual(Event.objects.count(), 10)
         for disbursement in disbursements:
-            self.assertTrue(RULES['HA'].triggered(disbursement))
+            triggered = RULES['HA'].triggered(disbursement)
+            self.assertTrue(triggered)
+            self.assertEqual(triggered.kwargs['amount'], disbursement.amount)
             events = RULES['HA'].create_events(disbursement)
             self.assertEventMatchesRecord(events, disbursement)
         self.assertEqual(Event.objects.count(), 20)
@@ -139,9 +151,13 @@ class RuleTestCase(TestCase):
         credits = Credit.objects.exclude(amount__gte=12000)
         disbursements = Disbursement.objects.exclude(amount__gte=12000)
         for credit in credits:
-            self.assertFalse(RULES['HA'].triggered(credit))
+            triggered = RULES['HA'].triggered(credit)
+            self.assertFalse(triggered)
+            self.assertEqual(triggered.kwargs['amount'], credit.amount)
         for disbursement in disbursements:
-            self.assertFalse(RULES['HA'].triggered(disbursement))
+            triggered = RULES['HA'].triggered(disbursement)
+            self.assertFalse(triggered)
+            self.assertEqual(triggered.kwargs['amount'], disbursement.amount)
         self.assertEqual(Event.objects.count(), 20)
 
     def test_create_events_for_monp_credit(self):
@@ -152,13 +168,17 @@ class RuleTestCase(TestCase):
 
         credits = Credit.objects.filter(prisoner_profile=prisoner_profile)
         for credit in credits:
-            self.assertTrue(RULES['MONP'].triggered(credit))
+            triggered = RULES['MONP'].triggered(credit)
+            self.assertTrue(triggered)
+            self.assertEqual(triggered.kwargs['monitoring_user_count'], 1)
             events = RULES['MONP'].create_events(credit)
             self.assertEventMatchesRecord(events, credit, PrisonerProfile)
 
         credits = Credit.objects.exclude(prisoner_profile=prisoner_profile)
         for credit in credits:
-            self.assertFalse(RULES['MONP'].triggered(credit))
+            triggered = RULES['MONP'].triggered(credit)
+            self.assertFalse(triggered)
+            self.assertEqual(triggered.kwargs['monitoring_user_count'], 0)
 
         self.assertEqual(Event.objects.count(), prisoner_profile.credits.count())
 
@@ -170,13 +190,17 @@ class RuleTestCase(TestCase):
 
         disbursements = Disbursement.objects.filter(prisoner_profile=prisoner_profile)
         for disbursement in disbursements:
-            self.assertTrue(RULES['MONP'].triggered(disbursement))
+            triggered = RULES['MONP'].triggered(disbursement)
+            self.assertTrue(triggered)
+            self.assertEqual(triggered.kwargs['monitoring_user_count'], 1)
             events = RULES['MONP'].create_events(disbursement)
             self.assertEventMatchesRecord(events, disbursement, PrisonerProfile)
 
         disbursements = Disbursement.objects.exclude(prisoner_profile=prisoner_profile)
         for disbursement in disbursements:
-            self.assertFalse(RULES['MONP'].triggered(disbursement))
+            triggered = RULES['MONP'].triggered(disbursement)
+            self.assertFalse(triggered)
+            self.assertEqual(triggered.kwargs['monitoring_user_count'], 0)
 
         self.assertEqual(Event.objects.count(), prisoner_profile.disbursements.count())
 
@@ -193,13 +217,17 @@ class RuleTestCase(TestCase):
 
         credits = Credit.objects.filter(sender_profile=sender_profile)
         for credit in credits:
-            self.assertTrue(RULES['MONS'].triggered(credit))
+            triggered = RULES['MONS'].triggered(credit)
+            self.assertTrue(triggered)
+            self.assertEqual(triggered.kwargs['monitoring_user_count'], 1)
             events = RULES['MONS'].create_events(credit)
             self.assertEventMatchesRecord(events, credit, SenderProfile)
 
         credits = Credit.objects.exclude(sender_profile=sender_profile)
         for credit in credits:
-            self.assertFalse(RULES['MONS'].triggered(credit))
+            triggered = RULES['MONS'].triggered(credit)
+            self.assertFalse(triggered)
+            self.assertEqual(triggered.kwargs['monitoring_user_count'], 0)
 
         self.assertEqual(Event.objects.count(), sender_profile.credits.count())
 
@@ -216,13 +244,17 @@ class RuleTestCase(TestCase):
 
         credits = Credit.objects.filter(sender_profile=sender_profile)
         for credit in credits:
-            self.assertTrue(RULES['MONS'].triggered(credit))
+            triggered = RULES['MONS'].triggered(credit)
+            self.assertTrue(triggered)
+            self.assertEqual(triggered.kwargs['monitoring_user_count'], 1)
             events = RULES['MONS'].create_events(credit)
             self.assertEventMatchesRecord(events, credit, SenderProfile)
 
         credits = Credit.objects.exclude(sender_profile=sender_profile)
         for credit in credits:
-            self.assertFalse(RULES['MONS'].triggered(credit))
+            triggered = RULES['MONS'].triggered(credit)
+            self.assertFalse(triggered)
+            self.assertEqual(triggered.kwargs['monitoring_user_count'], 0)
 
         self.assertEqual(Event.objects.count(), sender_profile.credits.count())
 
@@ -239,13 +271,17 @@ class RuleTestCase(TestCase):
 
         disbursements = Disbursement.objects.filter(recipient_profile=recipient_profile)
         for disbursement in disbursements:
-            self.assertTrue(RULES['MONR'].triggered(disbursement))
+            triggered = RULES['MONR'].triggered(disbursement)
+            self.assertTrue(triggered)
+            self.assertEqual(triggered.kwargs['monitoring_user_count'], 1)
             events = RULES['MONR'].create_events(disbursement)
             self.assertEventMatchesRecord(events, disbursement, RecipientProfile)
 
         disbursements = Disbursement.objects.exclude(recipient_profile=recipient_profile)
         for disbursement in disbursements:
-            self.assertFalse(RULES['MONR'].triggered(disbursement))
+            triggered = RULES['MONR'].triggered(disbursement)
+            self.assertFalse(triggered)
+            self.assertEqual(triggered.kwargs['monitoring_user_count'], 0)
 
         self.assertEqual(Event.objects.count(), recipient_profile.disbursements.count())
 
@@ -322,12 +358,15 @@ class CountingRuleTestCase(TestCase):
         rule = RULES['CSFREQ']
 
         # make just enough credits to trigger rule
-        credit_list = self.make_csfreq_credits(self.make_sender(), rule.kwargs['limit'] + 1)
+        count = rule.kwargs['limit'] + 1
+        credit_list = self.make_csfreq_credits(self.make_sender(), count)
 
         # latest credit triggers rule, but all older ones don't
         latest_credit = credit_list[0]
         self.assertTrue(rule.applies_to(latest_credit))
-        self.assertTrue(rule.triggered(latest_credit))
+        triggered = rule.triggered(latest_credit)
+        self.assertTrue(triggered)
+        self.assertEqual(triggered.kwargs['count'], count)
         for older_credit in credit_list[1:]:
             self.assertTrue(rule.applies_to(older_credit))
             self.assertFalse(rule.triggered(older_credit))
@@ -336,7 +375,9 @@ class CountingRuleTestCase(TestCase):
         oldest_credit = credit_list[-1]
         oldest_credit.received_at -= datetime.timedelta(days=30)
         oldest_credit.save()
-        self.assertFalse(rule.triggered(latest_credit))
+        triggered = rule.triggered(latest_credit)
+        self.assertFalse(triggered)
+        self.assertEqual(triggered.kwargs['count'], count - 1)
 
     def make_drfreq_disbursements(self, recipient, count):
         disbursement_list = []
@@ -357,12 +398,15 @@ class CountingRuleTestCase(TestCase):
         rule = RULES['DRFREQ']
 
         # make just enough disbursements to trigger rule
-        disbursement_list = self.make_drfreq_disbursements(self.make_recipient(), rule.kwargs['limit'] + 1)
+        count = rule.kwargs['limit'] + 1
+        disbursement_list = self.make_drfreq_disbursements(self.make_recipient(), count)
 
         # latest disbursement triggers rule, but all older ones don't
         latest_disbursement = disbursement_list[0]
         self.assertTrue(rule.applies_to(latest_disbursement))
-        self.assertTrue(rule.triggered(latest_disbursement))
+        triggered = rule.triggered(latest_disbursement)
+        self.assertTrue(triggered)
+        self.assertEqual(triggered.kwargs['count'], count)
         for older_disbursement in disbursement_list[1:]:
             self.assertTrue(rule.applies_to(older_disbursement))
             self.assertFalse(rule.triggered(older_disbursement))
@@ -371,7 +415,9 @@ class CountingRuleTestCase(TestCase):
         oldest_disbursement = disbursement_list[-1]
         oldest_disbursement.created -= datetime.timedelta(days=30)
         oldest_disbursement.save()
-        self.assertFalse(rule.triggered(latest_disbursement))
+        triggered = rule.triggered(latest_disbursement)
+        self.assertFalse(triggered)
+        self.assertEqual(triggered.kwargs['count'], count - 1)
 
     def make_csnum_credits(self, prisoner, count, sender_profile=None):
         credit_list = []
@@ -403,12 +449,15 @@ class CountingRuleTestCase(TestCase):
         rule = RULES['CSNUM']
 
         # make just enough credits to trigger rule
-        credit_list = self.make_csnum_credits(self.make_prisoner(), rule.kwargs['limit'] + 1)
+        count = rule.kwargs['limit'] + 1
+        credit_list = self.make_csnum_credits(self.make_prisoner(), count)
 
         # latest credit triggers rule, but all older ones don't
         latest_credit = credit_list[0]
         self.assertTrue(rule.applies_to(latest_credit))
-        self.assertTrue(rule.triggered(latest_credit))
+        triggered = rule.triggered(latest_credit)
+        self.assertTrue(triggered)
+        self.assertEqual(triggered.kwargs['count'], count)
         for older_credit in credit_list[1:]:
             self.assertTrue(rule.applies_to(older_credit))
             self.assertFalse(rule.triggered(older_credit))
@@ -417,7 +466,9 @@ class CountingRuleTestCase(TestCase):
         oldest_credit = credit_list[-1]
         oldest_credit.received_at -= datetime.timedelta(days=30)
         oldest_credit.save()
-        self.assertFalse(rule.triggered(latest_credit))
+        triggered = rule.triggered(latest_credit)
+        self.assertFalse(triggered)
+        self.assertEqual(triggered.kwargs['count'], count - 1)
 
         # make extra credits attached to another profile
         self.make_csnum_credits(self.make_prisoner(), 2, sender_profile=latest_credit.sender_profile)
@@ -445,12 +496,15 @@ class CountingRuleTestCase(TestCase):
         rule = RULES['DRNUM']
 
         # make just enough disbursements to trigger rule
-        disbursement_list = self.make_drnum_disbursements(self.make_prisoner(), rule.kwargs['limit'] + 1)
+        count = rule.kwargs['limit'] + 1
+        disbursement_list = self.make_drnum_disbursements(self.make_prisoner(), count)
 
         # latest disbursement triggers rule, but all older ones don't
         latest_disbursement = disbursement_list[0]
         self.assertTrue(rule.applies_to(latest_disbursement))
-        self.assertTrue(rule.triggered(latest_disbursement))
+        triggered = rule.triggered(latest_disbursement)
+        self.assertTrue(triggered)
+        self.assertEqual(triggered.kwargs['count'], count)
         for older_disbursement in disbursement_list[1:]:
             self.assertTrue(rule.applies_to(older_disbursement))
             self.assertFalse(rule.triggered(older_disbursement))
@@ -459,7 +513,9 @@ class CountingRuleTestCase(TestCase):
         oldest_disbursement = disbursement_list[-1]
         oldest_disbursement.created -= datetime.timedelta(days=30)
         oldest_disbursement.save()
-        self.assertFalse(rule.triggered(latest_disbursement))
+        triggered = rule.triggered(latest_disbursement)
+        self.assertFalse(triggered)
+        self.assertEqual(triggered.kwargs['count'], count - 1)
 
         # make extra disbursements attached to another profile
         self.make_drnum_disbursements(self.make_prisoner(), 2, recipient_profile=latest_disbursement.recipient_profile)
@@ -496,12 +552,15 @@ class CountingRuleTestCase(TestCase):
         rule = RULES['CPNUM']
 
         # make just enough credits to trigger rule
-        credit_list = self.make_cpnum_credits(self.make_sender(), rule.kwargs['limit'] + 1)
+        count = rule.kwargs['limit'] + 1
+        credit_list = self.make_cpnum_credits(self.make_sender(), count)
 
         # latest credit triggers rule, but all older ones don't
         latest_credit = credit_list[0]
         self.assertTrue(rule.applies_to(latest_credit))
-        self.assertTrue(rule.triggered(latest_credit))
+        triggered = rule.triggered(latest_credit)
+        self.assertTrue(triggered)
+        self.assertEqual(triggered.kwargs['count'], count)
         for older_credit in credit_list[1:]:
             self.assertTrue(rule.applies_to(older_credit))
             self.assertFalse(rule.triggered(older_credit))
@@ -510,7 +569,9 @@ class CountingRuleTestCase(TestCase):
         oldest_credit = credit_list[-1]
         oldest_credit.received_at -= datetime.timedelta(days=30)
         oldest_credit.save()
-        self.assertFalse(rule.triggered(latest_credit))
+        triggered = rule.triggered(latest_credit)
+        self.assertFalse(triggered)
+        self.assertEqual(triggered.kwargs['count'], count - 1)
 
         # make extra credits attached to another profile
         self.make_cpnum_credits(self.make_sender(), 2, prisoner_profile=latest_credit.prisoner_profile)
@@ -538,12 +599,15 @@ class CountingRuleTestCase(TestCase):
         rule = RULES['DPNUM']
 
         # make just enough disbursements to trigger rule
-        disbursement_list = self.make_dpnum_disbursements(self.make_recipient(), rule.kwargs['limit'] + 1)
+        count = rule.kwargs['limit'] + 1
+        disbursement_list = self.make_dpnum_disbursements(self.make_recipient(), count)
 
         # latest disbursement triggers rule, but all older ones don't
         latest_disbursement = disbursement_list[0]
         self.assertTrue(rule.applies_to(latest_disbursement))
-        self.assertTrue(rule.triggered(latest_disbursement))
+        triggered = rule.triggered(latest_disbursement)
+        self.assertTrue(triggered)
+        self.assertEqual(triggered.kwargs['count'], count)
         for older_disbursement in disbursement_list[1:]:
             self.assertTrue(rule.applies_to(older_disbursement))
             self.assertFalse(rule.triggered(older_disbursement))
@@ -552,7 +616,9 @@ class CountingRuleTestCase(TestCase):
         oldest_disbursement = disbursement_list[-1]
         oldest_disbursement.created -= datetime.timedelta(days=30)
         oldest_disbursement.save()
-        self.assertFalse(rule.triggered(latest_disbursement))
+        triggered = rule.triggered(latest_disbursement)
+        self.assertFalse(triggered)
+        self.assertEqual(triggered.kwargs['count'], count - 1)
 
         # make extra disbursements attached to another profile
         self.make_dpnum_disbursements(self.make_recipient(), 2, prisoner_profile=latest_disbursement.prisoner_profile)

--- a/mtp_api/apps/notification/tests/utils.py
+++ b/mtp_api/apps/notification/tests/utils.py
@@ -1,0 +1,173 @@
+import datetime
+
+from django.utils.crypto import get_random_string
+from faker import Faker
+from model_mommy import mommy
+
+from credit.models import Credit, CREDIT_RESOLUTION
+from credit.tests.utils import random_amount
+from disbursement.models import Disbursement, DISBURSEMENT_RESOLUTION
+from payment.models import Payment
+from prison.models import Prison
+from prison.tests.utils import random_prisoner_name, random_prisoner_number, random_prisoner_dob
+from security.models import (
+    SenderProfile, RecipientProfile, PrisonerProfile,
+    DebitCardSenderDetails, BankAccount, BankTransferRecipientDetails,
+)
+
+fake = Faker(locale='en_GB')
+
+
+def make_sender():
+    sender = SenderProfile.objects.create()
+    mommy.make(
+        DebitCardSenderDetails,
+        sender=sender,
+        card_number_last_digits=fake.credit_card_number()[-4:],
+        card_expiry_date=fake.credit_card_expire(),
+        postcode=fake.postcode(),
+    )
+    return sender
+
+
+def make_recipient():
+    recipient = RecipientProfile.objects.create()
+    bank_account = mommy.make(
+        BankAccount,
+        sort_code=get_random_string(6, '1234567890'),
+        account_number=get_random_string(8, '1234567890'),
+    )
+    mommy.make(BankTransferRecipientDetails, recipient=recipient, recipient_bank_account=bank_account)
+    return recipient
+
+
+def make_prisoner():
+    return mommy.make(
+        PrisonerProfile,
+        prisoner_name=random_prisoner_name(),
+        prisoner_number=random_prisoner_number(),
+        prisoner_dob=random_prisoner_dob(),
+        current_prison=Prison.objects.order_by('?').first(),
+    )
+
+
+def make_csfreq_credits(today, sender, count):
+    debit_card = sender.debit_card_details.first()
+    credit_list = []
+    for day in range(count):
+        credit = mommy.make(
+            Credit,
+            amount=random_amount(),
+            sender_profile=sender,
+            received_at=today - datetime.timedelta(day),
+            resolution=CREDIT_RESOLUTION.CREDITED, reconciled=True, private_estate_batch=None,
+        )
+        if debit_card:
+            payment = mommy.make(
+                Payment,
+                amount=credit.amount,
+                card_number_last_digits=debit_card.card_number_last_digits,
+                card_expiry_date=debit_card.card_expiry_date,
+            )
+            payment.credit = credit
+            payment.save()
+        credit_list.append(credit)
+    return credit_list
+
+
+def make_drfreq_disbursements(today, recipient, count):
+    disbursement_list = []
+    for day in range(count):
+        disbursement = mommy.make(
+            Disbursement,
+            amount=random_amount(),
+            recipient_profile=recipient,
+            created=today - datetime.timedelta(day),
+            resolution=DISBURSEMENT_RESOLUTION.SENT,
+        )
+        disbursement_list.append(disbursement)
+    return disbursement_list
+
+
+def make_csnum_credits(today, prisoner, count, sender_profile=None):
+    credit_list = []
+    for day in range(count):
+        sender = sender_profile or make_sender()
+        debit_card = sender.debit_card_details.first()
+        credit = mommy.make(
+            Credit,
+            amount=random_amount(),
+            sender_profile=sender,
+            prisoner_profile=prisoner,
+            received_at=today - datetime.timedelta(day),
+            resolution=CREDIT_RESOLUTION.CREDITED, reconciled=True, private_estate_batch=None,
+        )
+        if debit_card:
+            payment = mommy.make(
+                Payment,
+                amount=credit.amount,
+                card_number_last_digits=debit_card.card_number_last_digits,
+                card_expiry_date=debit_card.card_expiry_date,
+            )
+            payment.credit = credit
+            payment.save()
+        credit_list.append(credit)
+    return credit_list
+
+
+def make_drnum_disbursements(today, prisoner, count, recipient_profile=None):
+    disbursement_list = []
+    for day in range(count):
+        recipient = recipient_profile or make_recipient()
+        disbursement = mommy.make(
+            Disbursement,
+            amount=random_amount(),
+            recipient_profile=recipient,
+            prisoner_profile=prisoner,
+            created=today - datetime.timedelta(day),
+            resolution=DISBURSEMENT_RESOLUTION.SENT,
+        )
+        disbursement_list.append(disbursement)
+    return disbursement_list
+
+
+def make_cpnum_credits(today, sender, count, prisoner_profile=None):
+    debit_card = sender.debit_card_details.first()
+    credit_list = []
+    for day in range(count):
+        prisoner = prisoner_profile or make_prisoner()
+        credit = mommy.make(
+            Credit,
+            amount=random_amount(),
+            sender_profile=sender,
+            prisoner_profile=prisoner,
+            received_at=today - datetime.timedelta(day),
+            resolution=CREDIT_RESOLUTION.CREDITED, reconciled=True, private_estate_batch=None,
+        )
+        if debit_card:
+            payment = mommy.make(
+                Payment,
+                amount=credit.amount,
+                card_number_last_digits=debit_card.card_number_last_digits,
+                card_expiry_date=debit_card.card_expiry_date,
+            )
+            payment.credit = credit
+            payment.save()
+        credit_list.append(credit)
+    return credit_list
+
+
+def make_dpnum_disbursements(today, recipient, count, prisoner_profile=None):
+    disbursement_list = []
+    for day in range(count):
+        prisoner = prisoner_profile or make_prisoner()
+        disbursement = mommy.make(
+            Disbursement,
+            amount=random_amount(),
+            recipient_profile=recipient,
+            prisoner_profile=prisoner,
+            created=today - datetime.timedelta(day),
+            resolution=DISBURSEMENT_RESOLUTION.SENT,
+        )
+        disbursement_list.append(disbursement)
+    return disbursement_list


### PR DESCRIPTION
e.g. if the ‘How many?’ column says 6 for the rule ‘More than 4 credits from the same debit card or bank account to any prisoner in 4 weeks’, then this means that a specific debit card or bank account got 6 credits in 4 weeks up to when that credit was sent.