### PR TITLE
Add support for cloud platform migration

### DIFF
--- a/mtp_api/assets-src/stylesheets/app-ie8.scss
+++ b/mtp_api/assets-src/stylesheets/app-ie8.scss
@@ -1,0 +1,6 @@
+$is-ie: true;
+$ie-version: 8;
+
+@import 'app';
+
+@import 'elements/ie-support-banner';

--- a/mtp_api/assets-src/stylesheets/app.scss
+++ b/mtp_api/assets-src/stylesheets/app.scss
@@ -1,0 +1,1 @@
+@import 'mtp-internal';

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -71,6 +71,7 @@ ROOT_URLCONF = 'mtp_api.urls'
 MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
+    'mtp_common.cp_migration.middleware.CloudPlatformMigrationMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -308,6 +309,9 @@ OFFENDER_API_CLIENT_ID = os.environ.get('OFFENDER_API_CLIENT_ID', '')
 OFFENDER_API_CLIENT_SECRET = os.environ.get('OFFENDER_API_CLIENT_SECRET', '')
 
 INVOICE_NUMBER_BASE = 1000000
+
+CLOUD_PLATFORM_MIGRATION_MODE = os.environ.get('CLOUD_PLATFORM_MIGRATION_MODE', '')
+CLOUD_PLATFORM_MIGRATION_URL = os.environ.get('CLOUD_PLATFORM_MIGRATION_URL', '')
 
 try:
     from .local import *  # noqa

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=9.5,<9.6
+money-to-prisoners-common[testing]>=9.11.1,<9.12

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place your docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=9.5,<9.6
+money-to-prisoners-common[monitoring]>=9.11.1,<9.12
 
 uWSGI==2.0.17


### PR DESCRIPTION
This adds the cloud platform migration middleware and sets up the related settings values as env vars.

@ushkarev :

1. I had to add `app.scss` and `app-ie8.scss` as the page looked broken otherwise (the compiled versions are loaded by `mtp_base.html`). What do you think?

2. `mtp_base.html` also looks for `app.bundle.js` and `app-print.css` which 404. I guess it's not a problem?

