### PR TITLE
Add new notification target for Send Money

### DIFF
--- a/mtp_api/apps/service/migrations/0007_notification_areas.py
+++ b/mtp_api/apps/service/migrations/0007_notification_areas.py
@@ -9,6 +9,20 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='notification',
             name='target',
-            field=models.CharField(choices=[('bankadmin_login', 'Bank admin: before login'), ('bankadmin_dashboard', 'Bank admin: dashboard'), ('cashbook_login', 'Cashbook: before login'), ('cashbook_dashboard', 'Cashbook: dashboard'), ('cashbook_all', 'Cashbook: all apps'), ('cashbook_cashbook', 'Cashbook: cashbook app'), ('cashbook_disbursements', 'Cashbook: disbursements app'), ('noms_ops_login', 'Noms Ops: before login'), ('noms_ops_security_dashboard', 'Noms Ops: security dashboard')], max_length=30),
+            field=models.CharField(
+                choices=[
+                    ('bankadmin_login', 'Bank admin: before login'),
+                    ('bankadmin_dashboard', 'Bank admin: dashboard'),
+                    ('cashbook_login', 'Cashbook: before login'),
+                    ('cashbook_dashboard', 'Cashbook: dashboard'),
+                    ('cashbook_all', 'Cashbook: all apps'),
+                    ('cashbook_cashbook', 'Cashbook: cashbook app'),
+                    ('cashbook_disbursements', 'Cashbook: disbursements app'),
+                    ('noms_ops_login', 'Noms Ops: before login'),
+                    ('noms_ops_security_dashboard', 'Noms Ops: security dashboard'),
+                    ('send_money_landing', 'Send Money: landing page'),
+                ],
+                max_length=30,
+            ),
         ),
     ]

--- a/mtp_api/apps/service/models.py
+++ b/mtp_api/apps/service/models.py
@@ -44,6 +44,7 @@ NOTIFICATION_TARGETS = Choices(
     ('CASHBOOK_DISBURSEMENTS', 'cashbook_disbursements', 'Cashbook: disbursements app'),
     ('NOMS_OPS_LOGIN', 'noms_ops_login', 'Noms Ops: before login'),
     ('NOMS_OPS_SECURITY_DASHBOARD', 'noms_ops_security_dashboard', 'Noms Ops: security dashboard'),
+    ('SEND_MONEY_LANDING', 'send_money_landing', 'Send Money: landing page'),
 )
 
 


### PR DESCRIPTION
This adds a new send_money_landing target for notifications to appear on the landing page of the send money service.

I've changed the migration file directly as there's no database change so having a new file for this change is a bit of a waste.

I've only added an area for the landing page, not sure if we want one for all pages as well?