### PR TITLE
Turn off uwsgi "load data listener" daemon

### DIFF
--- a/api.ini
+++ b/api.ini
@@ -23,7 +23,7 @@ spooler-import = mtp_%n/tasks.py
 cron = 0 3 -1 -1 -1 %d/venv/bin/python %d/manage.py clean_up
 cron = -1 -1 -1 -1 -1 %d/venv/bin/python %d/manage.py run_scheduled_commands
 cron = 30 13 -1 -1 -1 %d/venv/bin/python %d/manage.py check_tokens
-attach-daemon = %d/venv/bin/python %d/manage.py load_data_listener
+# attach-daemon = %d/venv/bin/python %d/manage.py load_data_listener
 
 ; format uWSGI logs as JSON for ELK
 log-format = {"timestamp": "%(ltime)", "timestamp_msec": %(tmsecs), "@fields.logger": "uWSGI-Request", "@fields.http_host": "%(host)", "@fields.request_uri": "%(uri)", "@fields.request_method": "%(method)", "@fields.status": %(status), "@fields.response_time": %(micros)}


### PR DESCRIPTION
it was used for functional tests running on jenkins, but on prod, this daemon is constantly being relaunched and possibly degrades performance