### PR TITLE
Update uWSGI options

### DIFF
--- a/api.ini
+++ b/api.ini
@@ -1,21 +1,40 @@
 [uwsgi]
 procname = uwsgi_%n
+die-on-term = 1
+lazy-apps = 0
+vacuum = 1
 
-vhost = true
+master = true
+processes = 2
+enable-threads = true
+threads = 10
+
+chdir = %d
+virtualenv = %d/venv
+module = mtp_%n.wsgi:application
+
 http = :8080
 uid = www-data
 gid = www-data
 chmod-socket = 666
 chown-socket = www-data
-master = true
-enable-threads = true
-processes = 2
-chdir = %d
-virtualenv = %d/venv
-module = mtp_%n.wsgi:application
+
+no-defer-accept = 1
 post-buffering = 1
-http-timeout = 20
-buffer-size = 65535
+buffer-size = 12288
+http-timeout = 300
+http-keepalive = 60
+http-auto-chunked = 1
+add-header = Connection: keep-alive
+
+stats = 127.0.0.1:1717
+# read stats with `uwsgitop` or `uwsgi --connect-and-read 127.0.0.1:1717`
+
+log-x-forwarded-for = 1
+log-zero = 1
+log-ioerror = 1
+# format uWSGI logs as JSON for ELK
+# log-format = {"timestamp": "%(ltime)", "timestamp_msec": %(tmsecs), "@fields.logger": "uWSGI-Request", "@fields.http_host": "%(host)", "@fields.request_uri": "%(uri)", "@fields.request_method": "%(method)", "@fields.status": %(status), "@fields.response_time": %(micros)}
 
 spooler = %d/spooler
 spooler-chdir = %d
@@ -24,6 +43,3 @@ cron = 0 3 -1 -1 -1 %d/venv/bin/python %d/manage.py clean_up
 cron = -1 -1 -1 -1 -1 %d/venv/bin/python %d/manage.py run_scheduled_commands
 cron = 30 13 -1 -1 -1 %d/venv/bin/python %d/manage.py check_tokens
 # attach-daemon = %d/venv/bin/python %d/manage.py load_data_listener
-
-; format uWSGI logs as JSON for ELK
-log-format = {"timestamp": "%(ltime)", "timestamp_msec": %(tmsecs), "@fields.logger": "uWSGI-Request", "@fields.http_host": "%(host)", "@fields.request_uri": "%(uri)", "@fields.request_method": "%(method)", "@fields.status": %(status), "@fields.response_time": %(micros)}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ model-mommy>=1.5,<1.6
 django-moj-irat>=0.4
 django-anymail[mailgun]~=3.0
 crontab==0.21.3
-requests>=2.12,<3
+requests>=2.22,<3
 transifex-client>=0.12
 xlrd>=1.0.0,<2
 reportlab>=3.4,<4


### PR DESCRIPTION
… in the hope of making it work better with keep-alive/connection pooling issues that originate in urllib3.
also:
- simplify logging (CP kibana does not expand json logs into fields)
- add uwsgi stats server (only available inside container)
- hopefully improve k8s/docker compatibility