### PR TITLE
Remove template-deploy artefacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,18 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
+          name: Log into ECR
+          command: |
+            source /tmp/mtp-env.sh
+            $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
+      - run:
           name: Build docker image
           command: |
             source /tmp/mtp-env.sh
+            docker pull ${registry}:base-web
+            docker tag ${registry}:base-web base-web
             docker build \
-              --pull --force-rm \
+              --force-rm \
               --build-arg APP_GIT_COMMIT=${CIRCLE_SHA1} \
               --build-arg APP_GIT_BRANCH=${CIRCLE_BRANCH} \
               --build-arg APP_BUILD_TAG=${tag} \
@@ -63,7 +70,6 @@ jobs:
           name: Push docker image
           command: |
             source /tmp/mtp-env.sh
-            $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
             echo "Pushing ${tag} to ECR"
             docker tag ${tag} ${registry}:${tag}
             docker push ${registry}:${tag}
@@ -72,6 +78,10 @@ jobs:
               docker tag ${tag} ${registry}:${app}
               docker push ${registry}:${app}
             fi
+      - run:
+          name: Log out of ECR
+          command: |
+            source /tmp/mtp-env.sh
             docker logout ${ECR_ENDPOINT}
       - run:
           name: Deploy to test

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ministryofjustice/prisoner-money

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,12 @@
-FROM buildpack-deps:bionic
-
-# setup UK environment and install libraries and python
-RUN set -ex; \
-  apt-get update \
-  && \
-  DEBIAN_FRONTEND=noninteractive apt-get install \
-  -y --no-install-recommends --no-install-suggests \
-  -o DPkg::Options::=--force-confdef \
-  locales tzdata \
-  && \
-  echo en_GB.UTF-8 UTF-8 > /etc/locale.gen \
-  && \
-  locale-gen \
-  && \
-  rm /etc/localtime \
-  && \
-  ln -s /usr/share/zoneinfo/Europe/London /etc/localtime \
-  && \
-  dpkg-reconfigure --frontend noninteractive tzdata \
-  && \
-  DEBIAN_FRONTEND=noninteractive apt-get install \
-  -y --no-install-recommends --no-install-suggests \
-  -o DPkg::Options::=--force-confdef \
-  software-properties-common build-essential \
-  gettext rsync libssl1.0-dev \
-  python3-all-dev python3-setuptools python3-pip python3-wheel python3-venv \
-  nodejs nodejs-dev node-gyp npm \
-  chromium-browser \
-  && \
-  rm -rf /var/lib/apt/lists/* \
-  && \
-  npm set progress=false
-ENV LANG=en_GB.UTF-8
-ENV TZ=Europe/London
+FROM base-web
 
 # pre-create directories
-WORKDIR /app
 RUN set -ex; mkdir -p \
   mtp_api/assets \
   mtp_api/assets-static \
   static \
   media \
   spooler
-
-# install virtual environment
-RUN set -ex; \
-  /usr/bin/python3 -m venv venv && \
-  venv/bin/pip install -U setuptools pip wheel
 
 # cache python packages, unless requirements change
 COPY ./requirements requirements
@@ -56,8 +16,6 @@ RUN venv/bin/pip install -r requirements/docker.txt
 COPY . /app
 RUN set -ex; \
   venv/bin/python run.py --requirements-file requirements/docker.txt build \
-  && \
-  test $(id -u www-data) = 33 \
   && \
   chown -R www-data:www-data /app
 USER 33

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# Money to Prisoners API
+# API and Django admin
 
-The API app for the Money to Prisoners service. Currently, there are no APIs that are used by applications other than those that make up the Money to Prisoners Service.
+Backend and internal admin site for Prisoner Money suite of apps.
 
-[Apps and libraries used as part of this service](https://github.com/orgs/ministryofjustice/teams/money-to-prisoners/repositories)
+[Apps and libraries used as part of this service](https://github.com/ministryofjustice/money-to-prisoners)
 
 ## Requirements
 
 - Unix-like platform with Python 3.6+ and NodeJS
 - PostgreSQL
 
-## Developing locally
+## Developing
+
+[![CircleCI](https://circleci.com/gh/ministryofjustice/money-to-prisoners-api.svg?style=svg)](https://circleci.com/gh/ministryofjustice/money-to-prisoners-api)
 
 Create a PostgreSQL database called `mtp_api`.
 
@@ -20,55 +22,27 @@ Create a Django settings file for your local installation at `mtp_api/settings/l
 
 All build/development actions can be listed with `./run.py help`.
 
-Use `./run.py start` to run against the database configured in your local settings or `./run.py start --test-mode` to run it with auto-generated data (use this mode for running functional tests in client apps).
+Use `./run.py serve` to run against the database configured in your local settings or `./run.py start --test-mode` to run it with auto-generated data (use this mode for running functional tests in client apps).
+
+This will build everything and run the local server at [http://localhost:8000](http://localhost:8000).
 
 A dockerised version can be run locally with `./run.py local_docker`, but this does not run uWSGI like the deployed version does.
 
 ### Sample data generation
 
-As well as the management command (`./manage.py load_test_data`), the entire data set can also be regenerated from the Django admin tool (found at http://localhost:8000/admin/). Currently there are 2 scenarios:
+As well as the management command (`./manage.py load_test_data`), the entire data set can also be regenerated from [Django admin](http://localhost:8000/admin/recreate-test-data/).
 
-* Random transaction – the standard scenario for integration testing and development (the `load_test_data` command does this by default)
-* User testing the Cashbook – generates random uncredited transactions using offender names and locations from test NOMIS
-* Training data for the Cashbook
-* Delete prisoner location and credit data
-
-These scenarios create a different set of test users for the client applications – see the user list in the Django admin tool.
+These scenarios create a different set of test users for the client applications – see the user list in Django admin.
 
 ### Translating
 
 Update translation files with `./run.py make_messages` – you need to do this every time any translatable text is updated.
 
-Pull updates from Transifex with ``./run.py translations --pull``. You'll need to update translation files afterwards and manually check that the merges occurred correctly.
+Pull updates from Transifex with ``./run.py translations --pull``.
+You'll need to update translation files afterwards and manually check that the merges occurred correctly.
 
-Push latest English to Transifex with ``./run.py translations --push``. NB: you should pull updates before pushing to merge correctly.
-
-## Using the API
-### Getting an access token
-
-```
-curl -X POST -d "grant_type=password&username=<user_name>&password=<password>&client_id=<client_id>&client_secret=<client_secret>" http://localhost:8000/oauth2/token/
-```
-
-If you have executed the `./manage.py load_test_data` command then you'll have some users and a test oauth2 application already created. In which case execute the following command:
-
-```
-curl -X POST -d "grant_type=password&username=test_prison_1&password=test_prison_1&client_id=cashbook&client_secret=cashbook" http://localhost:8000/oauth2/token/
-```
-
-Which will return something like:
-
-```
-{
-    "expires_in": 36000,
-    "access_token": "R6mYyIzZQ03Kj95iEoD53FbLPGkL7Y",
-    "token_type": "Bearer",
-    "scope": "write read",
-    "refresh_token": "s57NweoHvPXahvmGklsrdDFMxxNSaf"
-}
-```
-
-Use the `access_token` in the response in subsequent requests.
+Push latest English to Transifex with ``./run.py translations --push``.
+NB: you should pull updates before pushing to merge correctly.
 
 ## Deploying
 

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -81,6 +81,7 @@ INSTALLED_APPS = (
 
     # common
     'mtp_common',
+    'mtp_common.metrics',
 )
 
 
@@ -100,6 +101,9 @@ MIDDLEWARE = (
 
 HEALTHCHECKS = ['moj_irat.healthchecks.database_healthcheck']
 AUTODISCOVER_HEALTHCHECKS = True
+
+METRICS_USER = os.environ.get('METRICS_USER', 'prom')
+METRICS_PASS = os.environ.get('METRICS_PASS', 'prom')
 
 # security tightening
 # some overridden in prod/docker settings where SSL is ensured

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -1,9 +1,3 @@
-"""
-Django settings for mtp_api project.
-
-For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.9/ref/settings/
-"""
 import os
 import sys
 from urllib.parse import urljoin

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -25,8 +25,32 @@ SECRET_KEY = 'CHANGE_ME'
 ALLOWED_HOSTS = []
 
 START_PAGE_URL = os.environ.get('START_PAGE_URL', 'https://www.gov.uk/send-prisoner-money')
-SITE_URL = os.environ.get('SITE_URL', 'http://localhost:8000')
-NOMS_OPS_URL = os.environ.get('NOMS_OPS_URL', 'http://localhost:8003')
+API_URL = (
+    f'https://{os.environ["PUBLIC_API_HOST"]}'
+    if os.environ.get('PUBLIC_API_HOST')
+    else 'http://localhost:8000'
+)
+CASHBOOK_URL = (
+    f'https://{os.environ["PUBLIC_CASHBOOK_HOST"]}'
+    if os.environ.get('PUBLIC_CASHBOOK_HOST')
+    else 'http://localhost:8001'
+)
+BANK_ADMIN_URL = (
+    f'https://{os.environ["PUBLIC_BANK_ADMIN_HOST"]}'
+    if os.environ.get('PUBLIC_BANK_ADMIN_HOST')
+    else 'http://localhost:8002'
+)
+NOMS_OPS_URL = (
+    f'https://{os.environ["PUBLIC_NOMS_OPS_HOST"]}'
+    if os.environ.get('PUBLIC_NOMS_OPS_HOST')
+    else 'http://localhost:8003'
+)
+SEND_MONEY_URL = (
+    f'https://{os.environ["PUBLIC_SEND_MONEY_HOST"]}'
+    if os.environ.get('PUBLIC_SEND_MONEY_HOST')
+    else 'http://localhost:8004'
+)
+SITE_URL = API_URL
 
 # Application definition
 INSTALLED_APPS = (
@@ -126,10 +150,7 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'assets'),
     os.path.join(BASE_DIR, 'assets-static'),
 ]
-
-PUBLIC_STATIC_URL = os.environ.get(
-    'PUBLIC_STATIC_URL', urljoin(SITE_URL, STATIC_URL)
-)
+PUBLIC_STATIC_URL = urljoin(SEND_MONEY_URL, STATIC_URL)
 
 TEMPLATES = [
     {

--- a/mtp_api/urls.py
+++ b/mtp_api/urls.py
@@ -4,8 +4,9 @@ from django.contrib import admin
 from django.http import HttpResponse
 from django.views.generic import RedirectView
 from django.utils.translation import gettext_lazy as _
-
 from moj_irat.views import HealthcheckView, PingJsonView
+from mtp_common.metrics.views import metrics_view
+
 from performance.view_dashboard import PerformanceDashboardView
 
 urlpatterns = [
@@ -33,6 +34,7 @@ urlpatterns = [
         version_number_key='APP_BUILD_TAG',
     ), name='ping_json'),
     url(r'^healthcheck.json$', HealthcheckView.as_view(), name='healthcheck_json'),
+    url(r'^metrics.txt$', metrics_view, name='prometheus_metrics'),
 
     url(r'^favicon.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'images/favicon.ico', permanent=True)),
     url(r'^robots.txt$', lambda request: HttpResponse('User-agent: *\nDisallow: /', content_type='text/plain')),

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=9.14,<9.15
+money-to-prisoners-common[testing]>=9.15,<9.16

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place your docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=9.14,<9.15
+money-to-prisoners-common[monitoring]>=9.15,<9.16
 
 uWSGI==2.0.18


### PR DESCRIPTION
- As apps are now able to discover each other, many environment variables are now redundant so they can be removed
- Apps now use base Docker images built by this repository (pulling from ECR or building locally) – this speeds up builds and ensures they have the same base OS
- Add prometheus service monitors for all apps
- Depends on [mtp-deploy#282](https://github.com/ministryofjustice/money-to-prisoners-deploy/pull/282)