### PR TITLE
Add credit_resolution filter to check list endpoint

### DIFF
--- a/mtp_api/apps/security/views.py
+++ b/mtp_api/apps/security/views.py
@@ -494,6 +494,9 @@ class CheckListFilter(django_filters.FilterSet):
     prisoner_number = django_filters.CharFilter(
         field_name='credit__prisoner_number', lookup_expr='exact',
     )
+    credit_resolution = django_filters.CharFilter(
+        field_name='credit__resolution', lookup_expr='exact',
+    )
 
     class Meta:
         model = Check


### PR DESCRIPTION
So that we can exclude the ones related to credits not in initial resolution state.