### PR TITLE
Refactor file handling in Analytical Platform dump

### DIFF
--- a/mtp_api/apps/core/management/commands/dump_for_ap.py
+++ b/mtp_api/apps/core/management/commands/dump_for_ap.py
@@ -1,4 +1,3 @@
-import argparse
 import csv
 import datetime
 import textwrap
@@ -26,7 +25,7 @@ class Command(BaseCommand):
         parser.add_argument('--after', help='Modified after date (inclusive)')
         parser.add_argument('--before', help='Modified before date (exclusive)')
         parser.add_argument('type', choices=list(Serialiser.serialisers), help='Type of object to dump')
-        parser.add_argument('path', type=argparse.FileType('wt'), help='Path to dump data to')
+        parser.add_argument('path', help='Path to dump data to')
 
     def handle(self, *args, **options):
         after = date_argument(options['after'])
@@ -36,11 +35,13 @@ class Command(BaseCommand):
 
         record_type = options['type']
         serialiser: Serialiser = Serialiser.serialisers[record_type]()
-        writer = csv.DictWriter(options['path'], serialiser.headers)
-        writer.writeheader()
-        records = serialiser.get_modified_records(after, before)
-        for record in records:
-            writer.writerow(serialiser.serialise(record))
+
+        with open(options['path'], 'wt') as csv_file:
+            writer = csv.DictWriter(csv_file, serialiser.headers)
+            writer.writeheader()
+            records = serialiser.get_modified_records(after, before)
+            for record in records:
+                writer.writerow(serialiser.serialise(record))
 
 
 class Serialiser:


### PR DESCRIPTION
In working with the `dump_for_ap` and uplaoding the results of the
export command, we ran into problems with the last 8kb of the exported
data remaining in the buffer when the file was worked with in the
command itself.

Although the final implementation will not be called while any export
data remains in the buffer, this was an unexpected complexity that could
be avoided.

Given that a `with` block closes a file when its finished, we think this
simplifies the export itself. Removing the `argsparse.FileType` however
meant that we didn't have ahook to stdout, so the tests had to update
to use temporary files.

This should also make the conversion to a JSON Lines format easier, as
we need to work with the data export without `csv.DictWriter` help.