### PR TITLE
Convert output file to JSON Lines format

### DIFF
--- a/mtp_api/apps/core/management/commands/dump_for_ap.py
+++ b/mtp_api/apps/core/management/commands/dump_for_ap.py
@@ -1,6 +1,6 @@
-import csv
 import datetime
 import textwrap
+import json
 
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
@@ -36,18 +36,17 @@ class Command(BaseCommand):
         record_type = options['type']
         serialiser: Serialiser = Serialiser.serialisers[record_type]()
 
-        with open(options['path'], 'wt') as csv_file:
-            writer = csv.DictWriter(csv_file, serialiser.headers)
-            writer.writeheader()
+        with open(options['path'], 'wt') as jsonl_file:
             records = serialiser.get_modified_records(after, before)
+
             for record in records:
-                writer.writerow(serialiser.serialise(record))
+                jsonl_file.write(json.dumps(serialiser.serialise(record), default=str, ensure_ascii=False))
+                jsonl_file.write('\n')
 
 
 class Serialiser:
     serialisers = {}
     serialised_model = None
-    headers = []
 
     def __init_subclass__(cls, serialised_model):
         record_type = str(serialised_model._meta.verbose_name_plural)
@@ -68,40 +67,6 @@ class Serialiser:
 
 
 class CreditSerialiser(Serialiser, serialised_model=Credit):
-    headers = Serialiser.headers + [
-        'Exported at',
-        'Internal ID',
-        'URL',
-        'Date started',
-        'Date received',
-        'Date credited',
-        'Amount',
-        'Prisoner number',
-        'Prisoner name',
-        'Prison',
-        'Owner username',
-        'Blocked',
-        'Sender name',
-        'Payment method',
-        'Bank transfer sort code',
-        'Bank transfer account',
-        'Bank transfer roll number',
-        'Debit card first six digits',
-        'Debit card last four digits',
-        'Debit card expiry',
-        'Debit card billing address line 1',
-        'Debit card billing address line 2',
-        'Debit card billing address city',
-        'Debit card billing address postcode',
-        'Debit card billing address country',
-        'Sender email',
-        'Sender IP address',
-        'Status',
-        'NOMIS transaction',
-        'WorldPay order code',
-        'Security check status',
-        'Security check codes',
-    ]
 
     def __init__(self):
         self.exported_at_local_time = timezone.now()
@@ -180,33 +145,6 @@ class CreditSerialiser(Serialiser, serialised_model=Credit):
 
 
 class DisbursementSerialiser(Serialiser, serialised_model=Disbursement):
-    headers = Serialiser.headers + [
-        'Exported at',
-        'Internal ID',
-        'URL',
-        'Date entered',
-        'Date confirmed',
-        'Date sent',
-        'Amount',
-        'Prisoner number',
-        'Prisoner name',
-        'Prison',
-        'Recipient first name',
-        'Recipient last name',
-        'Payment method',
-        'Bank transfer sort code',
-        'Bank transfer account',
-        'Bank transfer roll number',
-        'Recipient address line 1',
-        'Recipient address line 2',
-        'Recipient address city',
-        'Recipient address postcode',
-        'Recipient address country',
-        'Recipient email',
-        'Status',
-        'NOMIS transaction',
-        'SOP invoice number',
-    ]
 
     def __init__(self):
         self.exported_at_local_time = timezone.now()

--- a/mtp_api/apps/core/tests/test_dump_for_ap.py
+++ b/mtp_api/apps/core/tests/test_dump_for_ap.py
@@ -1,5 +1,5 @@
-import csv
 import datetime
+import json
 import tempfile
 from unittest import mock
 
@@ -14,6 +14,7 @@ from payment.constants import PAYMENT_STATUS
 from payment.models import Payment
 from payment.tests.utils import generate_payments
 from prison.tests.utils import load_random_prisoner_locations
+from transaction.tests.utils import generate_transactions
 
 
 class DumpForAPTestCase(TestCase):
@@ -49,22 +50,24 @@ class DumpForAPTestCase(TestCase):
         self.assertEqual(before.date(), datetime.date(2019, 9, 1))
 
     def test_empty_results(self):
-        with tempfile.NamedTemporaryFile() as csv_file:
-            call_command('dump_for_ap', 'credits', csv_file.name)
-            lines = open(csv_file.name).read().splitlines()
-        self.assertEqual(len(lines), 1)
+        with tempfile.NamedTemporaryFile() as export_file:
+            call_command('dump_for_ap', 'credits', export_file.name)
+            jsonlines = open(export_file.name).read().splitlines()
+
+        self.assertEqual(len(jsonlines), 0)
 
     def test_credits_dump_for_ap(self):
         self.basic_setup()
         generate_payments(payment_batch=20, days_of_history=2)
 
-        with tempfile.NamedTemporaryFile(mode='rt') as export_file:
+        with tempfile.NamedTemporaryFile() as export_file:
             call_command('dump_for_ap', 'credits', export_file.name)
+            jsonlines = open(export_file.name).read().splitlines()
 
-            csv_reader = csv.DictReader(export_file)
             credit_ids = []
-            for record in csv_reader:
-                credit_ids.append(int(record['Internal ID']))
+            for record in jsonlines:
+                parsedjson = json.loads(record)
+                credit_ids.append(parsedjson['Internal ID'])
 
         completed_payments = Payment.objects.exclude(
             status__in=(
@@ -80,13 +83,26 @@ class DumpForAPTestCase(TestCase):
         self.basic_setup()
         generate_disbursements(disbursement_batch=20, days_of_history=2)
 
-        with tempfile.NamedTemporaryFile(mode='rt') as export_file:
+        with tempfile.NamedTemporaryFile() as export_file:
             call_command('dump_for_ap', 'disbursements', export_file.name)
+            jsonlines = open(export_file.name).read().splitlines()
 
-            csv_reader = csv.DictReader(export_file)
             disbursement_ids = []
-            for record in csv_reader:
-                disbursement_ids.append(int(record['Internal ID']))
+            for record in jsonlines:
+                parsedjson = json.loads(record)
+                disbursement_ids.append(parsedjson['Internal ID'])
 
         expected_disbursement_ids = sorted(Disbursement.objects.values_list('pk', flat=True))
         self.assertListEqual(disbursement_ids, expected_disbursement_ids)
+
+    def test_debit_card_and_bank_transfer_data_included_in_export(self):
+        self.basic_setup()
+        generate_transactions(transaction_batch=1)
+        generate_payments(payment_batch=1)
+
+        with tempfile.NamedTemporaryFile() as export_file:
+            call_command('dump_for_ap', 'credits', export_file.name)
+            jsonlines = open(export_file.name).read()
+
+        self.assertIn('"Payment method": "Bank transfer"', jsonlines)
+        self.assertIn('"Payment method": "Debit card"', jsonlines)


### PR DESCRIPTION
This change is converting the previous data format of CSV to JSON Lines[1] as requested by the data team.

The change simplifies the code a little bit following the previous refactor (#583).

### Questions
- Should we worry about any previous data breaking the JSON encoding?
- Will all systems that we are exporting to use the right EOL sequence (i.e. will `\n` work in all environments this code will run on?)

1. http://jsonlines.org/