### PR TITLE
WIP Save a flag when a job information record is saved

### DIFF
--- a/mtp_api/apps/mtp_auth/serializers.py
+++ b/mtp_api/apps/mtp_auth/serializers.py
@@ -43,6 +43,7 @@ class JobInformationSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         user = self.context['request'].user
+        user.flags.create(name='provided-job-information')
         validated_data['user'] = user
         return super().create(validated_data)
 

--- a/mtp_api/apps/mtp_auth/tests/test_views.py
+++ b/mtp_api/apps/mtp_auth/tests/test_views.py
@@ -110,6 +110,16 @@ class JobInformationTestCase(APITestCase, AuthTestCaseMixin):
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0].user_id, self.security_staff.id)
 
+    def test_flag_created_when_job_info_saved(self):
+        self.client.post(
+            self.url,
+            data=self.payload,
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(self.security_staff)
+        )
+
+        flag_exists = Flag.objects.filter(user_id=self.security_staff.id, name='provided-job-information').exists()
+        self.assertTrue(flag_exists)
+
 
 class AuthBaseTestCase(APITestCase, AuthTestCaseMixin):
     fixtures = [


### PR DESCRIPTION
This adds the flag which will be used in the login process for the Intelligence app.

### Questions

- Is the create method in the Serializer the best place to save the flag record?
- We thought we might be able to access a user flags in the test (`self.security_staff.flags`) but this just returns `None` - should this be possible?