### PR TITLE
Account for British Summertime in tests

### DIFF
--- a/mtp_api/apps/credit/serializers.py
+++ b/mtp_api/apps/credit/serializers.py
@@ -49,7 +49,7 @@ class CreditSerializer(serializers.ModelSerializer):
     sender_name = serializers.CharField(read_only=True)
     sender_email = serializers.CharField(read_only=True)
     owner_name = serializers.CharField(read_only=True)
-    started_at = serializers.SerializerMethodField()
+    started_at = serializers.DateTimeField(read_only=True, source='payment.created')
     credited_at = serializers.DateTimeField(read_only=True)
     refunded_at = serializers.DateTimeField(read_only=True)
     set_manual_at = serializers.DateTimeField(read_only=True)
@@ -87,12 +87,6 @@ class CreditSerializer(serializers.ModelSerializer):
             'short_payment_ref',
             'nomis_transaction_id',
         )
-
-    def get_started_at(self, obj):
-        try:
-            return obj.payment.created
-        except AttributeError:
-            return None
 
     def get_anonymous(self, obj):
         try:

--- a/mtp_api/apps/security/tests/test_views.py
+++ b/mtp_api/apps/security/tests/test_views.py
@@ -1013,8 +1013,8 @@ class CheckListTestCase(BaseCheckTestCase):
             'credit__payment__created', flat=True
         ))
         check_count = len(credits_started_at)
-        earliest_check = credits_started_at[0]
-        latest_check = credits_started_at[-1]
+        earliest_check = credits_started_at[0].isoformat()
+        latest_check = credits_started_at[-1].isoformat()
 
         auth = self.get_http_authorization_for_user(self._get_authorised_user())
 
@@ -1034,19 +1034,19 @@ class CheckListTestCase(BaseCheckTestCase):
 
         assertCheckCount(
             {
-                'started_at__lt': earliest_check.strftime('%Y-%m-%d %H:%M:%S'),
+                'started_at__lt': earliest_check,
             },
             0
         )
         assertCheckCount(
             {
-                'started_at__gte': earliest_check.strftime('%Y-%m-%d %H:%M:%S'),
+                'started_at__gte': earliest_check,
             },
             check_count
         )
         assertCheckCount(
             {
-                'started_at__lt': latest_check.strftime('%Y-%m-%d %H:%M:%S'),
+                'started_at__lt': latest_check,
             },
             check_count - 1
         )


### PR DESCRIPTION
Change date format helper to use utc in tests
    
Jira: https://dsdmoj.atlassian.net/browse/MTP-1402

The `format_date_or_datetime` helper broke tests when the UK shifted to
BST, with a time offset. This meant that the Serializer returned a
formatted string including the offset hours, which didn't match the
actual date returned inthe JSON formatted check, as that remained a UTC
string.

The timezone of the dates for the test data is utc, however in the util
`format_date_or_datetime` used the django detected London timezone
in the serializer `to_representation`.

To ensure that the dates are comparative, we can set the timezone in the
utiity serializer call.

AND

Use isoformat() to retain timezone info
    
    The filter tests started failing *really* regularly due to the
    `strftime` dropping time zone info, which meant that the tests would not
    only return the latest check but all checks in the past hour, becuase
    timezones[1].
    
    Using isoformat to stringify the dates and retain timezone info fixes
    this and also simplifies the test a bit with no need to manually format
    a date.
