### PR TITLE
Run Check against created credit in load_test_data

### DIFF
--- a/mtp_api/apps/payment/tests/utils.py
+++ b/mtp_api/apps/payment/tests/utils.py
@@ -10,6 +10,7 @@ from faker import Faker
 from core.tests.utils import MockModelTimestamps
 from credit.constants import CREDIT_RESOLUTION
 from credit.models import Credit
+from security.models import Check
 from credit.tests.utils import (
     get_owner_and_status_chooser, create_credit_log, random_amount,
     build_sender_prisoner_pairs,
@@ -211,6 +212,7 @@ def save_payment(data):
     )
     credit.save()
     data['credit'] = credit
+    Check.objects.create_for_credit(credit)
 
     return Payment.objects.create(**data)
 


### PR DESCRIPTION
To better test the FIU pending credits page, it would be useful to
have a set of checks to display on the pending credits page.

While this will create a bank of automatically accepted Checks, digging
through the test data to create checks that are placed in the delayed
capture state was proving difficult, so we can come back to that.

To make these Checks show in the credits to action page for FIU we can
update their state in Django admin for the time being.