### PR TITLE
Allow send-money app to read combined account balances from NOMIS

### DIFF
--- a/mtp_api/apps/prison/tests/test_views.py
+++ b/mtp_api/apps/prison/tests/test_views.py
@@ -1,9 +1,12 @@
+import itertools
 import random
 from unittest import mock
 
 from django.urls import reverse
 from django.utils.dateformat import format as format_date
 from model_mommy import mommy
+from mtp_common.test_utils import silence_logger
+import requests
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -486,6 +489,90 @@ class PrisonerValidityViewTestCase(AuthTestCaseMixin, APITestCase):
         valid_data_with_filter['prisons'] = ','.join(other_prisons.values_list('nomis_id', flat=True))
         response = self.call_authorised_endpoint(valid_data_with_filter)
         self.assertEmptyResponse(response)
+
+
+class PrisonerAccountBalanceTestCase(AuthTestCaseMixin, APITestCase):
+    fixtures = ['initial_types.json', 'test_prisons.json', 'initial_groups.json']
+
+    def setUp(self):
+        super().setUp()
+
+        # make 1 prisoner in a public prison and in a private one
+        public_prison = Prison.objects.get(nomis_id='INP')
+        public_prison.private_estate = False
+        public_prison.save()
+        private_prison = Prison.objects.get(nomis_id='IXB')
+        private_prison.private_estate = True
+        private_prison.save()
+        load_random_prisoner_locations(number_of_prisoners=2)
+        prisoner_locations = PrisonerLocation.objects.order_by('?')[0:2]
+        prisoner_location_public, prisoner_location_private = prisoner_locations
+        prisoner_location_public.prison = public_prison
+        prisoner_location_public.save()
+        prisoner_location_private.prison = private_prison
+        prisoner_location_private.save()
+        self.prisoner_location_public = prisoner_location_public
+        self.prisoner_location_private = prisoner_location_private
+
+        # make standard users
+        test_users = make_test_users(clerks_per_prison=1, num_security_fiu_users=0)
+        send_money_users = test_users.pop('send_money_users')
+        self.send_money_user = send_money_users[0]
+        self.other_users = itertools.chain.from_iterable(test_users.values())
+
+    def make_api_call(self, prisoner_location, user=None):
+        prisoner_number = prisoner_location.prisoner_number
+        url = reverse('prisoner_account_balance-detail', kwargs={'prisoner_number': prisoner_number})
+        kwargs = {'format': 'json'}
+        if user:
+            kwargs['HTTP_AUTHORIZATION'] = self.get_http_authorization_for_user(user)
+        return self.client.get(url, **kwargs)
+
+    def test_fails_without_authentication(self):
+        response = self.make_api_call(self.prisoner_location_public)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED, msg='access without auth')
+
+    def test_fails_without_application_permissions(self):
+        for another_user in self.other_users:
+            response = self.make_api_call(self.prisoner_location_public, another_user)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, msg=f'accessed by {another_user}')
+
+    @mock.patch('prison.serializers.nomis')
+    def test_retrieving_combined_balance_in_public_estate(self, mocked_nomis):
+        mocked_nomis.get_account_balances.return_value = {'cash': 3000, 'spends': 550, 'savings': 12000}
+
+        response = self.make_api_call(self.prisoner_location_public, self.send_money_user)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertDictEqual(response_data, {'combined_account_balance': 3000 + 550 + 12000})
+
+    @mock.patch('prison.serializers.nomis')
+    def test_retrieving_combined_balance_in_private_estate(self, mocked_nomis):
+        mocked_nomis.get_account_balances.return_value = {'cash': 1000, 'spends': 550, 'savings': 12000}
+
+        response = self.make_api_call(self.prisoner_location_private, self.send_money_user)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertDictEqual(response_data, {'combined_account_balance': 0})
+        mocked_nomis.get_account_balances.assert_not_called()
+
+    @mock.patch('prison.serializers.nomis')
+    def test_nomis_error_propagates(self, mocked_nomis):
+        mocked_nomis.get_account_balances.side_effect = requests.HTTPError('403 Client Error: FORBIDDEN')
+
+        with silence_logger():
+            response = self.make_api_call(self.prisoner_location_public, self.send_money_user)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(b'Cannot lookup NOMIS balances', response.content)
+
+    @mock.patch('prison.serializers.nomis')
+    def test_unexpected_nomis_response(self, mocked_nomis):
+        mocked_nomis.get_account_balances.return_value = {'cash': 0}
+
+        with silence_logger():
+            response = self.make_api_call(self.prisoner_location_public, self.send_money_user)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(b'malformed', response.content)
 
 
 class PrisonViewTestCase(AuthTestCaseMixin, APITestCase):

--- a/mtp_api/apps/prison/urls.py
+++ b/mtp_api/apps/prison/urls.py
@@ -5,8 +5,8 @@ from prison import views
 
 router = routers.DefaultRouter()
 router.register(r'prisoner_locations', views.PrisonerLocationView, base_name='prisonerlocation')
-router.register(r'prisoner_validity', views.PrisonerValidityView,
-                base_name='prisoner_validity')
+router.register(r'prisoner_validity', views.PrisonerValidityView, base_name='prisoner_validity')
+router.register(r'prisoner_account_balances', views.PrisonerAccountBalanceView, base_name='prisoner_account_balance')
 router.register(r'prisons', views.PrisonView, base_name='prison')
 router.register(r'prison_populations', views.PopulationView, base_name='prison_population')
 router.register(r'prison_categories', views.CategoryView, base_name='prison_category')

--- a/mtp_api/apps/prison/views.py
+++ b/mtp_api/apps/prison/views.py
@@ -26,8 +26,10 @@ from mtp_auth.permissions import (
 from prison.forms import LoadOffendersForm
 from prison.models import PrisonerLocation, Category, Population, Prison
 from prison.serializers import (
-    PrisonerLocationSerializer, PrisonerValiditySerializer, PrisonSerializer,
-    PopulationSerializer, CategorySerializer
+    PrisonerLocationSerializer,
+    PrisonerValiditySerializer,
+    PrisonerAccountBalanceSerializer,
+    PrisonSerializer, PopulationSerializer, CategorySerializer,
 )
 from security.signals import prisoner_profile_current_prisons_need_updating
 
@@ -140,6 +142,17 @@ class PrisonerValidityView(mixins.ListModelMixin, viewsets.GenericViewSet):
                                             'fields are required'},
                             status=status.HTTP_400_BAD_REQUEST)
         return super().list(request, *args, **kwargs)
+
+
+class PrisonerAccountBalanceView(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    queryset = PrisonerLocation.objects.filter(active=True)
+    permission_classes = (
+        IsAuthenticated, SendMoneyClientIDPermissions,
+    )
+    serializer_class = PrisonerAccountBalanceSerializer
+    lookup_field = 'prisoner_number'
+    lookup_url_kwarg = 'prisoner_number'
+    lookup_value_regex = '[A-Za-z][0-9]{4}[A-Za-z]{2}'
 
 
 class PrisonView(mixins.ListModelMixin, viewsets.GenericViewSet):


### PR DESCRIPTION
[MTP-1465/MTP-1477](https://dsdmoj.atlassian.net/browse/MTP-1477)
- private cash, spends and savings account balances are combined into one total "combined_account_balance"
- balances are not available in private estate so 0 is returned; send-money will effectively ignore current balance
- errors from NOMIS are propagated to client
