### PR TITLE
Remove “Credit matched: ” prefix from security check description

### DIFF
--- a/mtp_api/apps/payment/tests/test_views.py
+++ b/mtp_api/apps/payment/tests/test_views.py
@@ -518,7 +518,7 @@ class GetPaymentViewTestCase(AuthTestCaseMixin, APITestCase):
         # reset check to pending
         check = payment.credit.security_check
         check.status = CHECK_STATUS.PENDING
-        check.description = 'Credit matched FIU monitoring rules'
+        check.description = ['Credit matched FIU monitoring rules']
         check.rules = ['FIUMONP']
         check.save()
         response = self.client.get(

--- a/mtp_api/apps/security/admin.py
+++ b/mtp_api/apps/security/admin.py
@@ -175,7 +175,11 @@ class CheckAdmin(admin.ModelAdmin):
     date_hierarchy = 'created'
     list_select_related = ('credit',)
     exclude = ('credit',)
-    readonly_fields = ('credit_link',)
+    readonly_fields = (
+        'rules',
+        'description',
+        'credit_link',
+    )
     actions = ['display_stats']
 
     @add_short_description(_('credit'))

--- a/mtp_api/apps/security/managers.py
+++ b/mtp_api/apps/security/managers.py
@@ -398,10 +398,10 @@ class CheckManager(models.Manager):
         matched_rule_codes = self._get_matching_rules(credit)
 
         if matched_rule_codes:
-            description = '. '.join(RULES[rule_code].description for rule_code in matched_rule_codes)
+            description = [RULES[rule_code].description for rule_code in matched_rule_codes]
             status = CHECK_STATUS.PENDING
         else:
-            description = 'Credit matched no rules and was automatically accepted'
+            description = ['Credit matched no rules and was automatically accepted']
             status = CHECK_STATUS.ACCEPTED
 
         return self.create(

--- a/mtp_api/apps/security/managers.py
+++ b/mtp_api/apps/security/managers.py
@@ -398,10 +398,7 @@ class CheckManager(models.Manager):
         matched_rule_codes = self._get_matching_rules(credit)
 
         if matched_rule_codes:
-            description = (
-                'Credit matched: ' +
-                '. '.join(RULES[rule_code].description for rule_code in matched_rule_codes)
-            )
+            description = '. '.join(RULES[rule_code].description for rule_code in matched_rule_codes)
             status = CHECK_STATUS.PENDING
         else:
             description = 'Credit matched no rules and was automatically accepted'

--- a/mtp_api/apps/security/migrations/0029_remove_check_description_prefix.py
+++ b/mtp_api/apps/security/migrations/0029_remove_check_description_prefix.py
@@ -1,0 +1,35 @@
+from django.db import migrations
+from django.db.models import Value
+from django.db.models.functions import Concat, Substr
+
+PREFIX = 'Credit matched: '
+
+
+def get_checks_with_matched_rules(apps):
+    """
+    Get all checks that matched at least one rule and did not have the old hard-coded description
+    """
+    check_cls = apps.get_model('security', 'Check')
+    checks_with_matched_rules = check_cls.objects \
+        .exclude(rules=[]) \
+        .exclude(description='Credit matched FIU monitoring rules')
+    return checks_with_matched_rules
+
+
+def remove_check_description_prefix(apps, schema_editor):
+    checks_with_matched_rules = get_checks_with_matched_rules(apps)
+    checks_with_matched_rules.update(description=Substr('description', len(PREFIX) + 1))
+
+
+def add_check_description_prefix(apps, schema_editor):
+    checks_with_matched_rules = get_checks_with_matched_rules(apps)
+    checks_with_matched_rules.update(description=Concat(Value(PREFIX), 'description'))
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('security', '0028_auto_20200624_1547'),
+    ]
+    operations = [
+        migrations.RunPython(code=remove_check_description_prefix, reverse_code=add_check_description_prefix),
+    ]

--- a/mtp_api/apps/security/migrations/0030_migrate_check_description.py
+++ b/mtp_api/apps/security/migrations/0030_migrate_check_description.py
@@ -1,0 +1,36 @@
+import django.contrib.postgres.fields
+from django.db import migrations, models
+
+
+SPLIT_CHECK_DESCRIPTION = '''
+UPDATE security_check
+SET description_migration = regexp_split_to_array(trim(description), '\\.\\s*');
+'''
+
+JOIN_CHECK_DESCRIPTION = '''
+UPDATE security_check
+SET description = array_to_string(description_migration, '. ');
+'''
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('security', '0029_remove_check_description_prefix'),
+    ]
+    operations = [
+        migrations.AddField(
+            model_name='check',
+            name='description_migration',
+            field=django.contrib.postgres.fields.ArrayField(base_field=models.CharField(max_length=100), blank=True, null=True, size=None),
+        ),
+        migrations.RunSQL(sql=SPLIT_CHECK_DESCRIPTION, reverse_sql=JOIN_CHECK_DESCRIPTION),
+        migrations.RemoveField(
+            model_name='check',
+            name='description',
+        ),
+        migrations.RenameField(
+            model_name='check',
+            old_name='description_migration',
+            new_name='description',
+        ),
+    ]

--- a/mtp_api/apps/security/migrations/0030_migrate_check_description.py
+++ b/mtp_api/apps/security/migrations/0030_migrate_check_description.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='check',
             name='description_migration',
-            field=django.contrib.postgres.fields.ArrayField(base_field=models.CharField(max_length=100), blank=True, null=True, size=None),
+            field=django.contrib.postgres.fields.ArrayField(base_field=models.CharField(max_length=200), blank=True, null=True, size=None),
         ),
         migrations.RunSQL(sql=SPLIT_CHECK_DESCRIPTION, reverse_sql=JOIN_CHECK_DESCRIPTION),
         migrations.RemoveField(

--- a/mtp_api/apps/security/models.py
+++ b/mtp_api/apps/security/models.py
@@ -307,7 +307,11 @@ class Check(TimeStampedModel):
         choices=CHECK_STATUS,
         db_index=True,
     )
-    description = models.CharField(max_length=500, blank=True)
+    description = ArrayField(
+        models.CharField(max_length=100),
+        null=True,
+        blank=True,
+    )
     rules = ArrayField(
         models.CharField(max_length=50),
         null=True,

--- a/mtp_api/apps/security/models.py
+++ b/mtp_api/apps/security/models.py
@@ -308,7 +308,7 @@ class Check(TimeStampedModel):
         db_index=True,
     )
     description = ArrayField(
-        models.CharField(max_length=100),
+        models.CharField(max_length=200),
         null=True,
         blank=True,
     )

--- a/mtp_api/apps/security/tests/test_checks.py
+++ b/mtp_api/apps/security/tests/test_checks.py
@@ -296,7 +296,8 @@ class CreditCheckTestCase(TestCase):
         self.assertTrue(credit.should_check())
         check = Check.objects.create_for_credit(credit)
         self.assertEqual(check.status, CHECK_STATUS.ACCEPTED)
-        self.assertIn('automatically accepted', check.description)
+        self.assertEqual(len(check.description), 1)
+        self.assertIn('automatically accepted', check.description[0])
         self.assertFalse(check.rules)
 
     def test_credit_without_profiles_checked_with_matched_rules(self):
@@ -310,8 +311,10 @@ class CreditCheckTestCase(TestCase):
         self.assertTrue(credit.should_check())
         check = Check.objects.create_for_credit(credit)
         self.assertEqual(check.status, CHECK_STATUS.PENDING)
-        self.assertIn('FIU prisoners', check.description)
-        self.assertIn('FIU payment sources', check.description)
+        self.assertEqual(len(check.description), 2)
+        description = '\n'.join(check.description)
+        self.assertIn('FIU prisoners', description)
+        self.assertIn('FIU payment sources', description)
         self.assertListEqual(sorted(check.rules), ['FIUMONP', 'FIUMONS'])
 
     def test_credit_with_profiles_checked_with_matched_rules(self):
@@ -327,8 +330,10 @@ class CreditCheckTestCase(TestCase):
         self.assertTrue(credit.should_check())
         check = Check.objects.create_for_credit(credit)
         self.assertEqual(check.status, CHECK_STATUS.PENDING)
-        self.assertIn('FIU prisoners', check.description)
-        self.assertIn('FIU payment sources', check.description)
+        self.assertEqual(len(check.description), 2)
+        description = '\n'.join(check.description)
+        self.assertIn('FIU prisoners', description)
+        self.assertIn('FIU payment sources', description)
         self.assertListEqual(sorted(check.rules), ['FIUMONP', 'FIUMONS'])
 
     def test_credit_with_matched_csfreq_rule(self):

--- a/mtp_api/apps/security/tests/test_views.py
+++ b/mtp_api/apps/security/tests/test_views.py
@@ -341,9 +341,9 @@ class SenderCreditListTestCase(SecurityViewTestCase):
             self.assertIn('actioned_by', datum['security_check'])
             if datum['id'] in accepted_checks:
                 self.assertEqual(datum['security_check']['status'], 'accepted')
-                self.assertEqual(
+                self.assertListEqual(
                     datum['security_check']['description'],
-                    'Credit matched no rules and was automatically accepted'
+                    ['Credit matched no rules and was automatically accepted'],
                 )
             if datum['id'] in rejected_checks:
                 self.assertEqual(datum['security_check']['status'], 'rejected')
@@ -730,9 +730,9 @@ class PrisonerCreditListTestCase(SecurityViewTestCase):
             self.assertIn('actioned_by', datum['security_check'])
             if datum['id'] in accepted_checks:
                 self.assertEqual(datum['security_check']['status'], 'accepted')
-                self.assertEqual(
+                self.assertListEqual(
                     datum['security_check']['description'],
-                    'Credit matched no rules and was automatically accepted'
+                    ['Credit matched no rules and was automatically accepted'],
                 )
             if datum['id'] in rejected_checks:
                 self.assertEqual(datum['security_check']['status'], 'rejected')
@@ -966,7 +966,7 @@ class BaseCheckTestCase(APITestCase, AuthTestCaseMixin):
                 credit=credit,
                 status=CHECK_STATUS.PENDING,
                 rules=['ABC', 'DEF'],
-                description='Failed rules',
+                description=['Failed rules'],
             )
 
         for credit in Credit.objects_all.filter(resolution=CREDIT_RESOLUTION.FAILED):
@@ -975,7 +975,7 @@ class BaseCheckTestCase(APITestCase, AuthTestCaseMixin):
                 credit=credit,
                 status=CHECK_STATUS.REJECTED,
                 rules=['ABC', 'DEF'],
-                description='Failed rules',
+                description=['Failed rules'],
                 actioned_at=now(),
                 actioned_by=self.security_fiu_users[0],
                 decision_reason='because...',
@@ -987,7 +987,7 @@ class BaseCheckTestCase(APITestCase, AuthTestCaseMixin):
                 credit=credit,
                 status=CHECK_STATUS.ACCEPTED,
                 rules=['ABC', 'DEF'],
-                description='Failed rules',
+                description=['Failed rules'],
                 actioned_at=now(),
                 actioned_by=self.security_fiu_users[0],
             )


### PR DESCRIPTION
…so that the description can be appropriately labelled depending on where it is displayed.

[MTP-1488](https://dsdmoj.atlassian.net/browse/MTP-1488)