### PR TITLE
admin: Fix search of sender profiles

### DIFF
--- a/mtp_api/apps/security/admin.py
+++ b/mtp_api/apps/security/admin.py
@@ -44,7 +44,7 @@ class SenderProfileAdmin(admin.ModelAdmin):
         DebitCardSenderDetailsAdminInline,
     )
     search_fields = (
-        'bank_transfer_details__sender_bank_account__sender_name',
+        'bank_transfer_details__sender_name',
         'bank_transfer_details__sender_bank_account__sort_code',
         'bank_transfer_details__sender_bank_account__account_number',
         'bank_transfer_details__sender_bank_account__roll_number',


### PR DESCRIPTION
A `SenderProfile` can have a `BankTransferSenderDetails` (when it's the
sender for a bank tranfer). This model has a `sender_name` field.

(the sender name was previously searched in the `BankAccount` model which
doesn't have a `sender_name` field)

Sentry exception: https://sentry.io/organizations/ministryofjustice/issues/2129937552/?project=2098210&project=2100450&project=2100423&project=2100458&project=2100467&project=2100463&query=is%3Aunresolved+assigned%3Ame&statsPeriod=14d

Part of ticket: https://dsdmoj.atlassian.net/browse/MTP-1773