### PR TITLE
admin: Credit details, make owner and private_estate_batch R/O

### DIFF
--- a/mtp_api/apps/credit/admin.py
+++ b/mtp_api/apps/credit/admin.py
@@ -109,8 +109,14 @@ class CreditAdmin(admin.ModelAdmin):
     date_hierarchy = 'received_at'
     inlines = (TransactionAdminInline, PaymentAdminInline, CommentAdminInline, LogAdminInline)
     readonly_fields = (
-        'resolution', 'reconciled', 'reviewed', 'blocked',
-        'sender_profile', 'prisoner_profile',
+        'resolution',
+        'reconciled',
+        'reviewed',
+        'blocked',
+        'sender_profile',
+        'prisoner_profile',
+        'owner',
+        'private_estate_batch',
     )
     list_filter = (
         StatusFilter,


### PR DESCRIPTION
These fields were editable which meant when seeing a Credit details
they were pulling extra data to populate the selects.

This page is used in a read-only fashion so these fields are now read-only
to speed-up the loading time of this page.

Ticket: https://dsdmoj.atlassian.net/browse/MTP-1800