### PR TITLE
CI: Run Django checks and check if code misses migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,17 @@ jobs:
         path: /tmp/reports
     - store_test_results:
         path: /tmp/reports
+  run_checks:
+    executor: build-test-push
+    steps:
+    - checkout
+    - setup_remote_docker:
+        docker_layer_caching: true
+    - attach_workspace:
+        at: imagedump
+    - run:
+        name: Run Django checks (including makemigrations --checks)
+        command: . ${CIRCLE_WORKING_DIRECTORY}/.circleci/custom_scripts/run_checks.sh
   push_docker_image:
     executor: build-test-push
     steps:
@@ -75,6 +86,9 @@ workflows:
   build-test-push:
     jobs:
       - build_service_image
+      - run_checks:
+          requires:
+            - build_service_image
       - test:
           requires:
             - build_service_image
@@ -87,4 +101,3 @@ workflows:
       - ecr_cleanup:
           requires:
             - push_docker_image
-

--- a/.circleci/custom_scripts/run_checks.sh
+++ b/.circleci/custom_scripts/run_checks.sh
@@ -5,15 +5,12 @@
 
 docker load -i "${CIRCLE_WORKING_DIRECTORY}/imagedump/${tag}.tar.gz"
 
-TESTMODULES=$(circleci tests glob "mtp_api/apps/**/tests/test_*.py" | circleci tests split --split-by=timings | tr "/" "." | sed 's/.py//g')
-
 docker run \
   --name ${app} \
   -e DJANGO_SETTINGS_MODULE=mtp_api.settings.ci \
   -e DB_PASSWORD=postgres \
   -e DB_USERNAME=postgres \
   -e DB_HOST=postgres \
-  -e TESTMODULES="$TESTMODULES" \
   --link postgres \
   ${tag} \
-  /bin/bash -cx '/app/venv/bin/pip install -r requirements/ci.txt && cd /app && venv/bin/python manage.py test ${TESTMODULES[*]} --verbosity=2'
+  /bin/bash -cx 'cd /app/ && venv/bin/python manage.py check --verbosity=2 && venv/bin/python manage.py makemigrations --check --verbosity=2'

--- a/.circleci/custom_scripts/start_db_container.sh
+++ b/.circleci/custom_scripts/start_db_container.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+docker run \
+  --name postgres \
+  --detach \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=mtp_api \
+  circleci/postgres:10.10-alpine
+
+sleep 10


### PR DESCRIPTION
Running some Django checks as part of our CI build pipeline:
- `./manage.py checks` and
- `./manage.py makemigrations --check` which would return a non-zero status when new migrations were generated. e.g. potentially we forgot to run `makemigrations` and we didn't include them

This additional `run_checks` job will run alongside the `test` job as it should be relatively fast and it's useful to know as soon as possible if we missed something in a PR for example.

**NOTE**: Also note that this would not block push of the docker image or deploy to test.
The assumption is that sometimes it may make sense to temporarily leave some DB schema changes/migrations out of a PR.

If we later on decide this checks should be blocking we can always change the CI workflow to be more draconian.

![Screenshot 2021-02-05 at 16 02 17](https://user-images.githubusercontent.com/238563/107057656-9d4ca500-67cb-11eb-8a4c-d957129aa34a.png)


Ticket: https://dsdmoj.atlassian.net/browse/MTP-1796