### PR TITLE
MTP-1734 auto accept lists

### DIFF
--- a/mtp_api/apps/mtp_auth/tests/mommy_recipes.py
+++ b/mtp_api/apps/mtp_auth/tests/mommy_recipes.py
@@ -111,13 +111,17 @@ def create_security_staff_user(name_and_password='security-staff', prisons=()):
     return ssu
 
 
-def create_security_fiu_user(name_and_password='security-fiu'):
+def create_security_fiu_user(name_and_password='security-fiu', first_name=None, last_name=None):
+    if not first_name:
+        first_name = 'Security FIU'
+    if not last_name:
+        last_name = 'Staff'
     groups = Group.objects.filter(name__in=['Security', 'FIU'])
     ssu = create_basic_user(
         name_and_password,
         groups,
-        first_name='Security FIU',
-        last_name='Staff',
+        first_name=first_name,
+        last_name=last_name,
     )
     ssu.flags.create(name='hmpps-employee')
 

--- a/mtp_api/apps/security/tests/test_checks.py
+++ b/mtp_api/apps/security/tests/test_checks.py
@@ -577,8 +577,8 @@ class AutoAcceptRuleTestCase(APITestCase, AuthTestCaseMixin):
                 'security-check-auto-accept-list'
             ),
             data={
-                'prisoner_profile': prisoner_profiles[0].id,
-                'debit_card_sender_details': sender_profiles[0].debit_card_details.first().id,
+                'prisoner_profile_id': prisoner_profiles[0].id,
+                'debit_card_sender_details_id': sender_profiles[0].debit_card_details.first().id,
                 'states': [
                     {
                         'reason': 'This person has amazing hair',

--- a/mtp_api/apps/security/tests/test_views/test_check_views.py
+++ b/mtp_api/apps/security/tests/test_views/test_check_views.py
@@ -600,8 +600,8 @@ class GetCheckTestCase(BaseCheckTestCase):
                 'security-check-auto-accept-list'
             ),
             data={
-                'prisoner_profile': PrisonerProfile.objects.first().id,
-                'debit_card_sender_details': SenderProfile.objects.first().debit_card_details.first().id,
+                'prisoner_profile_id': PrisonerProfile.objects.first().id,
+                'debit_card_sender_details_id': SenderProfile.objects.first().debit_card_details.first().id,
                 'states': [
                     {
                         'reason': 'This person has amazing hair',
@@ -973,10 +973,46 @@ class CheckAutoAcceptRuleViewTestCase(APITestCase, AuthTestCaseMixin):
         self.sender_profile = generate_sender_profiles_from_payments(number_of_senders=1, reassign_dcsd=True)[0]
         self.debit_card_sender_details = self.sender_profile.debit_card_details.first()
 
+    @staticmethod
+    def _prisoner_profile_to_api_dict(prisoner_profile):
+        return {
+            'created': format_date_or_datetime(prisoner_profile.created),
+            'credit_count': 0,
+            'credit_total': 0,
+            'current_prison': {
+                'name': prisoner_profile.current_prison.name,
+                'nomis_id': prisoner_profile.current_prison.nomis_id,
+            },
+            'disbursement_count': 0,
+            'disbursement_total': 0,
+            'id': prisoner_profile.id,
+            'modified': format_date_or_datetime(prisoner_profile.modified),
+            'prisoner_dob': prisoner_profile.prisoner_dob.isoformat(),
+            'prisoner_name': prisoner_profile.prisoner_name,
+            'prisoner_number': prisoner_profile.prisoner_number,
+            'prisons': [],
+            'provided_names': []
+        }
+
+    @staticmethod
+    def _debit_card_sender_details_to_api_dict(debit_card_sender_details):
+        return {
+            'card_expiry_date': debit_card_sender_details.card_expiry_date,
+            'card_number_last_digits': debit_card_sender_details.card_number_last_digits,
+            'cardholder_names': [],
+            'postcode': debit_card_sender_details.postcode,
+            'sender': debit_card_sender_details.id,
+            'sender_emails': []
+        }
+
     def test_auto_accept_rule_create(self):
         expected_response = {
-            'prisoner_profile': self.prisoner_profile.id,
-            'debit_card_sender_details': self.debit_card_sender_details.id,
+            'prisoner_profile': self._prisoner_profile_to_api_dict(
+                self.prisoner_profile
+            ),
+            'debit_card_sender_details': self._debit_card_sender_details_to_api_dict(
+                self.debit_card_sender_details
+            ),
             'states': [
                 {
                     'active': True,
@@ -994,8 +1030,8 @@ class CheckAutoAcceptRuleViewTestCase(APITestCase, AuthTestCaseMixin):
                 'security-check-auto-accept-list'
             ),
             data={
-                'prisoner_profile': self.prisoner_profile.id,
-                'debit_card_sender_details': self.debit_card_sender_details.id,
+                'prisoner_profile_id': self.prisoner_profile.id,
+                'debit_card_sender_details_id': self.debit_card_sender_details.id,
                 'states': [
                     {
                         'reason': 'they have amazing hair',
@@ -1042,8 +1078,8 @@ class CheckAutoAcceptRuleViewTestCase(APITestCase, AuthTestCaseMixin):
                 'security-check-auto-accept-list'
             ),
             data={
-                'prisoner_profile': self.prisoner_profile.id,
-                'debit_card_sender_details': self.debit_card_sender_details.id,
+                'prisoner_profile_id': self.prisoner_profile.id,
+                'debit_card_sender_details_id': self.debit_card_sender_details.id,
                 'states': [
                     {
                         'reason': 'they have amazing hair',
@@ -1061,8 +1097,8 @@ class CheckAutoAcceptRuleViewTestCase(APITestCase, AuthTestCaseMixin):
                 'security-check-auto-accept-list'
             ),
             data={
-                'prisoner_profile': self.prisoner_profile.id,
-                'debit_card_sender_details': self.debit_card_sender_details.id,
+                'prisoner_profile_id': self.prisoner_profile.id,
+                'debit_card_sender_details_id': self.debit_card_sender_details.id,
                 'states': [
                     {
                         'reason': 'Oh I know, dont they just',
@@ -1087,8 +1123,12 @@ class CheckAutoAcceptRuleViewTestCase(APITestCase, AuthTestCaseMixin):
 
     def test_auto_accept_rule_deactivate(self):
         expected_response = {
-            'prisoner_profile': self.prisoner_profile.id,
-            'debit_card_sender_details': self.debit_card_sender_details.id,
+            'prisoner_profile': self._prisoner_profile_to_api_dict(
+                self.prisoner_profile
+            ),
+            'debit_card_sender_details': self._debit_card_sender_details_to_api_dict(
+                self.debit_card_sender_details
+            ),
             'states': [
                 {
                     'active': True,
@@ -1115,8 +1155,8 @@ class CheckAutoAcceptRuleViewTestCase(APITestCase, AuthTestCaseMixin):
                 'security-check-auto-accept-list'
             ),
             data={
-                'prisoner_profile': self.prisoner_profile.id,
-                'debit_card_sender_details': self.debit_card_sender_details.id,
+                'prisoner_profile_id': self.prisoner_profile.id,
+                'debit_card_sender_details_id': self.debit_card_sender_details.id,
                 'states': [
                     {
                         'reason': 'they have amazing hair',
@@ -1171,8 +1211,12 @@ class CheckAutoAcceptRuleViewTestCase(APITestCase, AuthTestCaseMixin):
 
     def test_auto_accept_rule_reactivate(self):
         expected_response = {
-            'prisoner_profile': self.prisoner_profile.id,
-            'debit_card_sender_details': self.debit_card_sender_details.id,
+            'prisoner_profile': self._prisoner_profile_to_api_dict(
+                self.prisoner_profile
+            ),
+            'debit_card_sender_details': self._debit_card_sender_details_to_api_dict(
+                self.debit_card_sender_details
+            ),
             'states': [
                 {
                     'active': True,
@@ -1208,8 +1252,8 @@ class CheckAutoAcceptRuleViewTestCase(APITestCase, AuthTestCaseMixin):
                 'security-check-auto-accept-list'
             ),
             data={
-                'prisoner_profile': self.prisoner_profile.id,
-                'debit_card_sender_details': self.debit_card_sender_details.id,
+                'prisoner_profile_id': self.prisoner_profile.id,
+                'debit_card_sender_details_id': self.debit_card_sender_details.id,
                 'states': [
                     {
                         'reason': 'they have amazing hair',
@@ -1284,8 +1328,12 @@ class CheckAutoAcceptRuleViewTestCase(APITestCase, AuthTestCaseMixin):
             'next': None,
             'previous': None,
             'results': [{
-                'prisoner_profile': self.prisoner_profile.id,
-                'debit_card_sender_details': self.debit_card_sender_details.id,
+                'prisoner_profile': self._prisoner_profile_to_api_dict(
+                    self.prisoner_profile
+                ),
+                'debit_card_sender_details': self._debit_card_sender_details_to_api_dict(
+                    self.debit_card_sender_details
+                ),
                 'states': [
                     {
                         'active': True,
@@ -1304,8 +1352,8 @@ class CheckAutoAcceptRuleViewTestCase(APITestCase, AuthTestCaseMixin):
                 'security-check-auto-accept-list'
             ),
             data={
-                'prisoner_profile': self.prisoner_profile.id,
-                'debit_card_sender_details': self.debit_card_sender_details.id,
+                'prisoner_profile_id': self.prisoner_profile.id,
+                'debit_card_sender_details_id': self.debit_card_sender_details.id,
                 'states': [
                     {
                         'reason': 'they have amazing hair',

--- a/mtp_api/apps/security/tests/utils.py
+++ b/mtp_api/apps/security/tests/utils.py
@@ -244,8 +244,8 @@ def generate_checks(
                 check_auto_accept_rule = CheckAutoAcceptRuleSerializer(
                     context={'request': Mock(user=user)}
                 ).create({
-                    'debit_card_sender_details': check.credit.payment.billing_address.debit_card_sender_details,
-                    'prisoner_profile': check.credit.prisoner_profile,
+                    'debit_card_sender_details_id': check.credit.payment.billing_address.debit_card_sender_details,
+                    'prisoner_profile_id': check.credit.prisoner_profile,
                     'states': [{'reason': f'I am an automatically generated auto-accept number {i}'}]
                 })
             except IntegrityError:

--- a/mtp_api/apps/security/views.py
+++ b/mtp_api/apps/security/views.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.db.models import Count, Exists, OuterRef, Q
+from django.db.models import Count, Exists, OuterRef, Q, Subquery
 from django.shortcuts import get_object_or_404
 import django_filters
 from django_filters.rest_framework import DjangoFilterBackend
@@ -27,6 +27,7 @@ from security.models import (
     BankAccount,
     Check,
     CheckAutoAcceptRule,
+    CheckAutoAcceptRuleState,
     DebitCardSenderDetails,
     PrisonerProfile,
     RecipientProfile,
@@ -597,6 +598,11 @@ class CheckAutoAcceptRuleFilter(BaseFilterSet):
     prisoner_profile_id = django_filters.ModelChoiceFilter(
         field_name='prisoner_profile_id', queryset=PrisonerProfile.objects.all()
     )
+    is_active = django_filters.BooleanFilter(
+        field_name='last_state_active',
+        method='get_is_active',
+    )
+
     ordering = django_filters.OrderingFilter(
         fields=(
             ('states__added_by__last_name', 'states__added_by__last_name'),
@@ -605,6 +611,18 @@ class CheckAutoAcceptRuleFilter(BaseFilterSet):
             ('-states__created', '-states__created'),
         )
     )
+
+    def get_is_active(self, queryset, name, value):
+        last_state = CheckAutoAcceptRuleState.objects.filter(
+            auto_accept_rule_id=OuterRef('pk')
+        ).order_by(
+            '-created'
+        )
+        return queryset.annotate(
+            last_state_active=Subquery(last_state.values('active')[:1])
+        ).filter(
+            last_state_active=value
+        )
 
     class Meta:
         model = CheckAutoAcceptRule

--- a/mtp_api/apps/security/views.py
+++ b/mtp_api/apps/security/views.py
@@ -597,6 +597,18 @@ class CheckAutoAcceptRuleFilter(BaseFilterSet):
     prisoner_profile_id = django_filters.ModelChoiceFilter(
         field_name='prisoner_profile_id', queryset=PrisonerProfile.objects.all()
     )
+    ordering = django_filters.OrderingFilter(
+        fields=(
+            ('states__added_by__last_name', 'states__added_by__last_name'),
+            ('states__created', 'states__created'),
+            ('-states__added_by__last_name', '-states__added_by__last_name'),
+            ('-states__created', '-states__created'),
+        )
+    )
+
+    class Meta:
+        model = CheckAutoAcceptRule
+        fields = ['states__added_by__last_name', 'states__created']
 
 
 class CheckAutoAcceptRuleView(
@@ -609,8 +621,10 @@ class CheckAutoAcceptRuleView(
     filter_backends = (DjangoFilterBackend, filters.OrderingFilter)
     filter_class = CheckAutoAcceptRuleFilter
     serializer_class = CheckAutoAcceptRuleSerializer
-    ordering_fields = ('created',)
-    ordering = ('created',)
+    ordering_fields = (
+        'states_created', '-states_created',
+        'states__added_by__last_name', '-states__added_by__last_name',
+    )
     permission_classes = (
         IsAuthenticated,
         SecurityProfilePermissions,

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,3 +11,4 @@ django-pudb3
 pudb
 django-stubs
 djangorestframework-stubs
+types-requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,3 +8,6 @@ parameterized==0.7.4
 pdbpp
 django-pdb
 django-pudb3
+pudb
+django-stubs
+djangorestframework-stubs


### PR DESCRIPTION
Jira: https://dsdmoj.atlassian.net/browse/MTP-1734

Related PRs
noms-ops:  https://github.com/ministryofjustice/money-to-prisoners-noms-ops/pull/512

TODO
* [x] Figure out how validation is supposed to work with the Django 2.2 deprecation of `{field}_id` in the serializer context for the case of passing in an identifier on create/update and expecting a serialized instance on list
* [ ] Manual test against https://github.com/ministryofjustice/money-to-prisoners-noms-ops/pull/512