### PR TITLE
Fix migration

### DIFF
--- a/mtp_api/apps/security/migrations/0031_check_rejection_reasons.py
+++ b/mtp_api/apps/security/migrations/0031_check_rejection_reasons.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='check',
             name='rejection_reasons',
-            field=django.contrib.postgres.fields.jsonb.JSONField(default={}),
+            field=django.contrib.postgres.fields.jsonb.JSONField(default=dict),
         ),
     ]


### PR DESCRIPTION
to match change made in commit: aabb048cb409a9622496c15baee1862212ce5173

This has no effect on the database fields in postgres so a fix-up to an old migration is valid; it's not necessary to make a new migration and deploy.

So now CI ~should be~ is happy that migration files match models.