### PR TITLE
Add dev-prison-api scenario to load_test_data

### DIFF
--- a/mtp_api/apps/core/forms.py
+++ b/mtp_api/apps/core/forms.py
@@ -15,6 +15,7 @@ class RecreateTestDataForm(forms.Form):
         choices=(
             ('cashbook', _('User testing the Cashbook service')),
             ('nomis-api-dev', _('NOMIS API dev env data')),
+            ('dev-prison-api', _('Get prisoner locations from dev Prison API')),
             ('random', _('Random set of credits')),
             ('delete-locations-credits', _('Delete prisoner location and credit data')),
             ('production-scale', _('Delete nothing, add entities to similar order of magnitude as production')),

--- a/mtp_api/apps/core/management/commands/load_test_data.py
+++ b/mtp_api/apps/core/management/commands/load_test_data.py
@@ -21,7 +21,12 @@ from payment.models import Batch, Payment
 from payment.tests.utils import generate_payments
 from performance.tests.utils import generate_digital_takeup
 from prison.models import Prison, PrisonerLocation
-from prison.tests.utils import load_prisoner_locations_from_file, load_random_prisoner_locations
+from prison.tests.utils import (
+    load_prisoner_locations_from_file,
+    load_random_prisoner_locations,
+    load_prisoner_locations_from_dev_prison_api,
+)
+
 from security.tests.utils import (
     generate_checks,
     generate_prisoner_profiles_from_prisoner_locations,
@@ -49,10 +54,10 @@ class Command(BaseCommand):
         parser.add_argument('--protect-credits', action='store_true',
                             help='Prevents existing credits from being deleted')
         parser.add_argument('--prisons', nargs='*', default=['sample'],
-                            choices=['sample', 'nomis', 'mtp', 'nomis-api-dev'],
+                            choices=['sample', 'nomis', 'mtp', 'nomis-api-dev', 'dev-prison-api'],
                             help='Create prisons from these sets')
         parser.add_argument('--prisoners', nargs='*', default=['sample'],
-                            choices=['sample', 'nomis', 'nomis-api-dev'],
+                            choices=['sample', 'nomis', 'nomis-api-dev', 'dev-prison-api'],
                             help='Create prisoners from these sets')
         parser.add_argument('--number-of-prisoners', default=50, type=int,
                             help='Number of sample prisoners to create (no effect for nomis)')
@@ -207,6 +212,8 @@ class Command(BaseCommand):
             fixtures.append('test_nomis_mtp_prisons.json')
         if 'nomis-api-dev' in prisons:
             fixtures.append('dev_nomis_api_prisons.json')
+        if 'dev-prison-api' in prisons:
+            fixtures.append('dev_prison_api_prisons.json')
         print_message('Loading default user group and selected prison fixtures')
         call_command('loaddata', *fixtures, verbosity=verbosity)
 
@@ -226,6 +233,8 @@ class Command(BaseCommand):
             prisoner_locations = load_prisoner_locations_from_file('test_nomis_prisoner_locations.csv')
         if 'nomis-api-dev' in prisoners:
             prisoner_locations = load_prisoner_locations_from_file('dev_nomis_api_prisoner_locations.csv')
+        if 'dev-prison-api' in prisoners:
+            prisoner_locations = load_prisoner_locations_from_dev_prison_api(number_of_prisoners=number_of_prisoners)
         if 'sample' in prisoners:
             prisoner_locations = load_random_prisoner_locations(number_of_prisoners=number_of_prisoners)
         if not prisoner_locations:

--- a/mtp_api/apps/prison/fixtures/dev_prison_api_prisons.json
+++ b/mtp_api/apps/prison/fixtures/dev_prison_api_prisons.json
@@ -16,5 +16,41 @@
         3
       ]
     }
+  },
+  {
+    "model": "prison.prison",
+    "pk": "NMI",
+    "fields": {
+        "modified": "2016-12-01T12:00:00Z",
+        "region": "East Midlands",
+        "name": "HMP Nottingham",
+        "created": "2015-10-28T12:00:00Z",
+        "general_ledger_code": "10200770",
+        "populations": [
+            1,
+            3
+        ],
+        "categories": [
+            2
+        ]
+    }
+  },
+  {
+    "model": "prison.prison",
+    "pk": "WLI",
+    "fields": {
+        "modified": "2016-12-01T12:00:00Z",
+        "region": "East of England",
+        "name": "HMP Wayland",
+        "created": "2015-10-28T12:00:00Z",
+        "general_ledger_code": "10201060",
+        "populations": [
+            1,
+            3
+        ],
+        "categories": [
+            3
+        ]
+    }
   }
 ]

--- a/mtp_api/apps/prison/fixtures/dev_prison_api_prisons.json
+++ b/mtp_api/apps/prison/fixtures/dev_prison_api_prisons.json
@@ -1,0 +1,20 @@
+[
+  {
+    "model": "prison.prison",
+    "pk": "BWI",
+    "fields": {
+      "name": "HMP Berwyn",
+      "region": "Wales",
+      "general_ledger_code": "10201160",
+      "created": "2017-01-23T12:00:00Z",
+      "modified": "2017-01-23T12:00:00Z",
+      "populations": [
+        1,
+        3
+      ],
+      "categories": [
+        3
+      ]
+    }
+  }
+]

--- a/mtp_api/apps/prison/tests/test_utils.py
+++ b/mtp_api/apps/prison/tests/test_utils.py
@@ -1,0 +1,108 @@
+import re
+import json
+
+from django.conf import settings
+from django.core.management import call_command
+from django.test import override_settings, TestCase
+import responses
+
+from prison.models import PrisonerLocation
+from prison.tests.utils import (
+    load_prisoner_locations_from_dev_prison_api,
+    random_prisoner_number,
+    random_prisoner_name,
+    random_prisoner_dob,
+)
+
+
+
+class LoadPrisonerLocationsFromDevPrisonAPITestCase(TestCase):
+
+    fixtures = [
+        'initial_types.json',
+        'initial_groups.json',
+        'dev_prison_api_prisons.json',
+    ]
+
+    def setUp(self):
+        self.prison_id = 'BWI'  # HMP Berwyn is present in dev HMPPS Prison API
+        self.n_prisoners_api = 10
+        self.n_prisoners_desired = 5
+
+        self.prisoners = {}
+        for _ in range(self.n_prisoners_api):
+            prisoner_id = random_prisoner_number()
+            self.prisoners[prisoner_id] = self.random_prisoner()
+
+    def random_prisoner(self):
+        full_name = random_prisoner_name()
+        first_name = full_name.split(' ')[0]
+        last_name = full_name.split(' ')[1]
+        return {
+            'given_name': first_name,
+            'middle_names': '',
+            'surname': last_name,
+            'date_of_birth': str(random_prisoner_dob()),
+            # HMPPS Prison API returns more information not included here
+        }
+
+    def get_offender_info_callback(self, request):
+        prisoner_id = request.path_url.split('/')[-1]
+        prisoner_info = self.prisoners[prisoner_id]
+
+        return (200, {}, json.dumps(prisoner_info))
+
+    @override_settings(
+        HMPPS_CLIENT_SECRET='test-secret',
+        HMPPS_AUTH_BASE_URL='https://sign-in-dev.hmpps.local/auth/',
+        HMPPS_PRISON_API_BASE_URL='https://api-dev.prison.local/',
+    )
+    def test_load_prisoner_locations_from_dev_prison_api(self):
+        n_prisoner_locations_before = PrisonerLocation.objects.count()
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                f'{settings.HMPPS_AUTH_BASE_URL}oauth/token',
+                json={
+                    'access_token': 'amanaccesstoken',
+                    'expires_in': 3600,
+                },
+            )
+            rsps.add(
+                responses.GET,
+                f'{settings.HMPPS_PRISON_API_BASE_URL}api/v1/prison/{self.prison_id}/live_roll',
+                json={
+                    'noms_ids': list(self.prisoners.keys()),
+                }
+            )
+            rsps.add_callback(
+                responses.GET,
+                re.compile(f'{settings.HMPPS_PRISON_API_BASE_URL}api/v1/offenders/*'),
+                callback=self.get_offender_info_callback,
+            )
+
+            load_prisoner_locations_from_dev_prison_api(self.n_prisoners_desired)
+
+        n_prisoner_locations_after = PrisonerLocation.objects.count()
+        n_prisoner_locations_created = n_prisoner_locations_after - n_prisoner_locations_before
+
+        self.assertEqual(self.n_prisoners_desired, n_prisoner_locations_created)
+
+        expected_prisoner_ids = list(self.prisoners.keys())
+        expected_prisoner_ids.sort()
+        for prisoner_id in expected_prisoner_ids[:self.n_prisoners_desired]:
+            prisoner_info = self.prisoners[prisoner_id]
+
+            location = PrisonerLocation.objects.filter(
+                prisoner_number=prisoner_id,
+                prison_id=self.prison_id,
+            )
+
+            self.assertTrue(location.exists())
+
+            location = location.first()
+            self.assertEqual(location.prisoner_number, prisoner_id)
+            expected_name = prisoner_info['given_name'] + ' ' + prisoner_info['surname']
+            self.assertEqual(location.prisoner_name, expected_name)
+            self.assertEqual(str(location.prisoner_dob), prisoner_info['date_of_birth'])


### PR DESCRIPTION
This scenario generates PrisonerLocation for prisoners present in the
`dev` version of HMPPS Prison API.

Limitations
-----------
This scenario relies on few well known prisons being present in the
`dev` api. There isn't an endpoint to get a list of prisons so this may
break in the future if these prison are removed from `dev`.

Refactorings
------------
I've also used this opportunity to tidy up `RecreateTestDataView` and
moved the various scenarios configuration in a dictionary and removed
the long `if`/`elif` chain.

See
---
HMPPS Prison API documentation: https://api.prison.service.justice.gov.uk/swagger-ui/index.html

Ticket: https://dsdmoj.atlassian.net/browse/MTP-1490