### PR TITLE
MTP-1537: Move dependencies in mtp-common

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=11.0.1
+money-to-prisoners-common~=11.1.0
 
 psycopg2-binary>=2.8.4,<2.9
 djangorestframework>=3.9.1,<3.10.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,7 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=10.1.0
+money-to-prisoners-common~=11.0.1
 
-Django>=2.2.16,<2.3
 psycopg2-binary>=2.8.4,<2.9
 djangorestframework>=3.9.1,<3.10.0
 drf-yasg==1.17.1
@@ -12,14 +11,9 @@ oauthlib>=2.1,<3
 django-oauth-toolkit==1.2.0
 drf-extensions==0.3.1
 drf-nested-routers==0.11.1
-django-extended-choices>=1.3,<2
 Faker>=0.8,<0.9
 model-mommy>=1.5,<1.6
-django-moj-irat>=0.6
-django-anymail[mailgun]~=7.2
 crontab==0.21.3
-requests>=2.22,<3
-transifex-client>=0.13,<0.14
 xlrd>=1.0.0,<2
 reportlab>=3.4,<4
 numpy>=1.18,<2
@@ -27,4 +21,3 @@ scipy>=1.4,<2
 openpyxl>=2.6,<2.7
 boto3>=1.12,<2
 dictdiffer==0.8.1
-uWSGI==2.0.19.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=10.1.0
+money-to-prisoners-common[testing]~=11.1.0
 
 -r base.txt
 


### PR DESCRIPTION
This is using a newer version of `mtp-common` (`11.1.0`).

⚠️ **NOTE**: as we bump from `10.x` to `11.x` and that new version contains some other changes (e.g. GDS design system changes) - this probably need some coordination before we merge it.

Ticket: https://dsdmoj.atlassian.net/browse/MTP-1537