### PR TITLE
Fixed duplicate parameter error in swagger without impacting production functionality

### DIFF
--- a/mtp_api/apps/core/tests/test_swagger.py
+++ b/mtp_api/apps/core/tests/test_swagger.py
@@ -1,0 +1,12 @@
+
+from rest_framework.test import APITestCase
+
+
+class TestSwagger(APITestCase):
+
+    def test_get(self):
+        response = self.client.get(
+            '/swagger/?format=openapi',
+            follow=True
+        )
+        self.assertEquals(response.status_code, 200)

--- a/mtp_api/apps/security/views.py
+++ b/mtp_api/apps/security/views.py
@@ -637,7 +637,7 @@ class CheckAutoAcceptRuleView(
     viewsets.GenericViewSet,
 ):
     queryset = CheckAutoAcceptRule.objects.all()
-    filter_backends = (DjangoFilterBackend, filters.OrderingFilter)
+    filter_backends = (DjangoFilterBackend,)
     filter_class = CheckAutoAcceptRuleFilter
     serializer_class = CheckAutoAcceptRuleSerializer
     ordering_fields = (

--- a/mtp_api/apps/security/views.py
+++ b/mtp_api/apps/security/views.py
@@ -626,7 +626,12 @@ class CheckAutoAcceptRuleFilter(BaseFilterSet):
 
     class Meta:
         model = CheckAutoAcceptRule
-        fields = ['states__added_by__first_name', 'states__created']
+        fields = [
+            'debit_card_sender_details_id',
+            'prisoner_profile_id',
+            'states__added_by__first_name',
+            'states__created'
+        ]
 
 
 class CheckAutoAcceptRuleView(


### PR DESCRIPTION
Whilst developing against MTP-1805, I realized the `CheckAutoAcceptRuleView` endpoint had broken swagger because there were two `ordering` parameters; one provided by `filters.OrderingFilter` and one provided by `CheckAutoAcceptRuleFilter`. Since the former can't filter on related fields, and was being overridden by the latter I removed the former.

I also added a simple test to spot this issue if it occurs again. I put it in `core/tests/` for lack of a better place, but i'm open to moving it