### PR TITLE
Stop posting stats to GOV.UK Performance Platform

### DIFF
--- a/api.ini
+++ b/api.ini
@@ -41,5 +41,4 @@ spooler-chdir = %d
 spooler-import = mtp_%n/tasks.py
 cron = 0 3 -1 -1 -1 %d/venv/bin/python %d/manage.py clean_up
 cron = -1 -1 -1 -1 -1 %d/venv/bin/python %d/manage.py run_scheduled_commands
-cron = 30 13 -1 -1 -1 %d/venv/bin/python %d/manage.py check_tokens
 # attach-daemon = %d/venv/bin/python %d/manage.py load_data_listener

--- a/mtp_api/apps/performance/forms.py
+++ b/mtp_api/apps/performance/forms.py
@@ -10,8 +10,6 @@ from django.db import transaction
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
-from core.models import ScheduledCommand
-
 logger = logging.getLogger('mtp')
 
 
@@ -148,12 +146,3 @@ class DigitalTakeupUploadForm(forms.Form):
                 date=self.date,
                 prison_id=nomis_id,
             )
-
-        datestr = self.date.strftime('%Y-%m-%dT00:00:00')
-        job = ScheduledCommand(
-            name='update_performance_platform',
-            arg_string='--resources transactions-by-channel-type --timestamp %s' % datestr,
-            cron_entry='*/10 * * * *',
-            delete_after_next=True
-        )
-        job.save()

--- a/mtp_api/apps/performance/management/commands/update_performance_platform.py
+++ b/mtp_api/apps/performance/management/commands/update_performance_platform.py
@@ -1,3 +1,7 @@
+"""
+NB: GOV.UK have retired the performance platform
+"""
+
 from datetime import datetime
 
 from django.core.management import BaseCommand

--- a/mtp_api/apps/performance/migrations/0004_retire_performance_platform.py
+++ b/mtp_api/apps/performance/migrations/0004_retire_performance_platform.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+
+
+def remove_performance_platform_update(apps, schema_editor):
+    cls = apps.get_model('core', 'ScheduledCommand')
+    cls.objects.filter(name='update_performance_platform').delete()
+
+
+def restore_performance_platform_update(apps, schema_editor):
+    cls = apps.get_model('core', 'ScheduledCommand')
+    cls.objects.create(
+        name='update_performance_platform',
+        arg_string='--resources completion-rate',
+        cron_entry='0 5 * * Mon',
+    )
+    cls.objects.create(
+        name='update_performance_platform',
+        arg_string='--resources transactions-by-channel-type',
+        cron_entry='50 22 * * *',
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0005_delete_token'),
+        ('performance', '0003_credit_amounts'),
+    ]
+    operations = [
+        migrations.RunPython(
+            remove_performance_platform_update,
+            reverse_code=restore_performance_platform_update,
+        )
+    ]

--- a/mtp_api/apps/performance/tests/test_forms.py
+++ b/mtp_api/apps/performance/tests/test_forms.py
@@ -4,7 +4,6 @@ import pathlib
 from django.test import TestCase
 from django.core.files.base import File
 
-from core.models import ScheduledCommand
 from performance.forms import DigitalTakeupUploadForm
 from performance.models import DigitalTakeup
 
@@ -24,7 +23,6 @@ class DigitalTakeupUploadTestCase(TestCase):
                                                                            form.errors.as_text()))
             form.save()
         self.assertEqual(DigitalTakeup.objects.count(), 111)
-        self.assertEqual(ScheduledCommand.objects.count(), 2)
 
         sample_date = datetime.date(2016, 11, 2)
         self.assertAlmostEqual(DigitalTakeup.objects.mean_digital_takeup(), 0.19, places=2)

--- a/mtp_api/apps/performance/updaters.py
+++ b/mtp_api/apps/performance/updaters.py
@@ -1,3 +1,7 @@
+"""
+NB: GOV.UK have retired the performance platform
+"""
+
 import base64
 from datetime import datetime, time, timedelta
 import logging

--- a/mtp_api/apps/performance/view_dashboard.py
+++ b/mtp_api/apps/performance/view_dashboard.py
@@ -15,11 +15,17 @@ COST_PER_TRANSACTION_BY_DIGITAL = 2.22
 
 
 def get_user_satisfaction():
-    yearly_data = requests.get(
-        'https://www.performance.service.gov.uk/data/send-prisoner-money/customer-satisfaction?'
-        'flatten=true&duration=1&period=year&collect=rating_1%3Asum&collect=rating_2%3Asum&collect=rating_3%3Asum&'
-        'collect=rating_4%3Asum&collect=rating_5%3Asum&collect=total%3Asum&format=json'
-    ).json()
+    try:
+        response = requests.get(
+            'https://www.performance.service.gov.uk/data/send-prisoner-money/customer-satisfaction?'
+            'flatten=true&duration=1&period=year&collect=rating_1%3Asum&collect=rating_2%3Asum&collect=rating_3%3Asum&'
+            'collect=rating_4%3Asum&collect=rating_5%3Asum&collect=total%3Asum&format=json'
+        )
+        response.raise_for_status()
+    except requests.RequestException:
+        return 'Not available'
+
+    yearly_data = response.json()
     yearly_data = yearly_data['data'][0]
 
     total_satisfied_year = yearly_data['rating_4:sum'] + yearly_data['rating_5:sum']


### PR DESCRIPTION
…because GDS have killed it off. The functionality for posting stats remains, but is no longer scheduled to run periodically.