### PR TITLE
Fix asset building and include latest dependencies from mtp-common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ node_modules/
 npm-debug.log
 
 # app-specific
+.eslintrc.json
+.sass-lint.yml
 docker-compose.yml
 package.json
 package-lock.json

--- a/mtp_api/assets-src/javascripts/credit-report.js
+++ b/mtp_api/assets-src/javascripts/credit-report.js
@@ -1,4 +1,4 @@
-/* globals django, google, creditReportData */
+/* globals google, creditReportData */
 
 django.jQuery(function ($) {
   'use strict';
@@ -127,7 +127,7 @@ django.jQuery(function ($) {
 
       if ($chartRect.size()) {
         for (var weekend in creditReportData.weekends) {
-          if (!creditReportData.weekends.hasOwnProperty(weekend)) {
+          if (!Object.prototype.hasOwnProperty.call(creditReportData.weekends, weekend)) {
             continue;
           }
           weekend = creditReportData.weekends[weekend];
@@ -152,7 +152,7 @@ django.jQuery(function ($) {
   google.charts.setOnLoadCallback(function () {
     chartData = new google.visualization.DataTable();
     for (var column in creditReportData.columns) {
-      if (creditReportData.columns.hasOwnProperty(column)) {
+      if (Object.prototype.hasOwnProperty.call(creditReportData.columns, column)) {
         chartData.addColumn(creditReportData.columns[column]);
       }
     }

--- a/mtp_api/assets-src/javascripts/dashboard.js
+++ b/mtp_api/assets-src/javascripts/dashboard.js
@@ -1,4 +1,4 @@
-/* globals django, Cookies */
+/* globals Cookies */
 
 django.jQuery(function ($) {
   'use strict';
@@ -76,7 +76,7 @@ django.jQuery(function ($) {
     $button.text($button.data('close-label'));
     $button.off('click');
     for (var prefix in prefixes) {
-      if (prefixes.hasOwnProperty(prefix)) {
+      if (Object.prototype.hasOwnProperty.call(prefixes, prefix)) {
         var method = prefixes[prefix] ? prefixes[prefix] + 'RequestFullscreen' : 'requestFullscreen';
         if (dashboardWrapper[method]) {
           dashboardWrapper[method]();

--- a/mtp_api/assets-src/javascripts/google-charts.js
+++ b/mtp_api/assets-src/javascripts/google-charts.js
@@ -1,4 +1,4 @@
-/* globals django, google */
+/* globals google */
 
 django.jQuery(function () {
   'use strict';

--- a/mtp_api/assets-src/javascripts/performance-dashboard.js
+++ b/mtp_api/assets-src/javascripts/performance-dashboard.js
@@ -1,4 +1,5 @@
-/* globals django, google, creditData, digitalTakeupData, disbursementData */
+/* globals google, creditData, digitalTakeupData, disbursementData */
+'use strict';
 
 var $ = django.jQuery;
 google.charts.load('current', { 'packages': ['corechart']});

--- a/mtp_api/assets-src/javascripts/performance-overview.js
+++ b/mtp_api/assets-src/javascripts/performance-overview.js
@@ -1,4 +1,4 @@
-/* globals django, google, performanceData */
+/* globals google, performanceData */
 'use strict';
 
 function performanceChart ($, data, $chart) {

--- a/mtp_api/assets-src/javascripts/satisfaction-results.js
+++ b/mtp_api/assets-src/javascripts/satisfaction-results.js
@@ -1,4 +1,4 @@
-/* globals django, google, satisfactionResultsData */
+/* globals google, satisfactionResultsData */
 
 django.jQuery(function ($) {
   'use strict';
@@ -56,7 +56,7 @@ django.jQuery(function ($) {
 
       // draw coloured tabs
       for (i in colourScale) {
-        if (colourScale.hasOwnProperty(i)) {
+        if (Object.prototype.hasOwnProperty.call(colourScale, i)) {
           var colour = colourScale[i];
           var barBounds = cli.getBoundingBox('bar#0#' + i);
           var $rect = $(document.createElementNS(svgNamespace, 'rect'));
@@ -75,7 +75,7 @@ django.jQuery(function ($) {
 
       // draw mean bars
       for (i in means) {
-        if (means.hasOwnProperty(i)) {
+        if (Object.prototype.hasOwnProperty.call(means, i)) {
           var mean = means[i];
           var $meanMarker = $(document.createElementNS(svgNamespace, 'rect'));
           var $meanTextMarker = $(document.createElementNS(svgNamespace, 'text'));
@@ -154,7 +154,7 @@ django.jQuery(function ($) {
       var chartData = new google.visualization.DataTable();
 
       for (var column in satisfactionResultsData.columns) {
-        if (satisfactionResultsData.columns.hasOwnProperty(column)) {
+        if (Object.prototype.hasOwnProperty.call(satisfactionResultsData.columns, column)) {
           chartData.addColumn(satisfactionResultsData.columns[column]);
         }
       }

--- a/mtp_api/assets-src/stylesheets/app-ie8.scss
+++ b/mtp_api/assets-src/stylesheets/app-ie8.scss
@@ -1,4 +1,0 @@
-$is-ie: true;
-$ie-version: 8;
-
-@import 'app';

--- a/mtp_api/assets-src/stylesheets/app.scss
+++ b/mtp_api/assets-src/stylesheets/app.scss
@@ -1,1 +1,0 @@
-@import 'mtp-internal';

--- a/mtp_api/assets-src/stylesheets/performance-dashboard.scss
+++ b/mtp_api/assets-src/stylesheets/performance-dashboard.scss
@@ -1,4 +1,4 @@
-@import 'colours/palette';
+@import 'govuk-frontend/govuk/settings/all';
 
 body {
   padding-left: 100px;
@@ -95,42 +95,42 @@ td {
 }
 
 .yellow {
-  color: $yellow;
+  color: govuk-colour('yellow');
 
   .legend &::before {
-    background: $yellow;
+    background: govuk-colour('yellow');
   }
 }
 
 .pink {
-  color: $pink;
+  color: govuk-colour('pink');
 
   .legend &::before {
-    background: $pink;
+    background: govuk-colour('pink');
   }
 }
 
 .purple {
-  color: $mauve;
+  color: govuk-colour('light-purple');
 
   .legend &::before {
-    background: $mauve;
+    background: govuk-colour('light-purple');
   }
 }
 
 .green {
-  color: $grass-green;
+  color: govuk-colour('light-green');
 
   .legend &::before {
-    background: $grass-green;
+    background: govuk-colour('light-green');
   }
 }
 
 .blue {
-  color: $light-blue;
+  color: govuk-colour('light-blue');
 
   .legend &::before {
-    background: $light-blue;
+    background: govuk-colour('light-blue');
   }
 }
 

--- a/mtp_api/assets-src/stylesheets/performance-dashboard.scss
+++ b/mtp_api/assets-src/stylesheets/performance-dashboard.scss
@@ -1,52 +1,48 @@
 @import 'govuk-frontend/govuk/settings/all';
 
 body {
-  padding-left: 100px;
-  padding-right: 100px;
-  padding-top: 30px;
-  padding-bottom: 30px;
+  padding: 30px 100px;
   margin: 0;
-  background-color: #27332F;
+  background-color: #27332f;
   font-family: Arial, Helvetica, sans-serif;
-  color: white;
+  color: #fff;
   font-size: 25px;
 }
 
 a.pause-button {
   position: fixed;
   bottom: 20px;
-  left: 30;
+  left: 30px;
   padding: 4px 8px;
-  color: white;
+  color: #fff;
 }
 
 h1 {
   font-size: 70px;
-  margin: 0px;
   font-weight: lighter;
-  margin: 0px;
+  margin: 0;
 }
 
 h2 {
   font-size: 40px;
-  margin: 0px;
+  margin: 0;
 }
 
 h3 {
   font-size: 35px;
   font-weight: lighter;
-  margin: 0px;
+  margin: 0;
 }
 
 h4 {
   font-size: 30px;
   font-weight: lighter;
-  margin: 0px;
+  margin: 0;
 }
 
 td {
-  margin: 0px;
-  padding: 0px;
+  margin: 0;
+  padding: 0;
   vertical-align: top;
 }
 
@@ -140,14 +136,14 @@ td {
 
 .table-overview {
   border-collapse: separate;
-  border-spacing: 50px 0px;
+  border-spacing: 50px 0;
   font-size: 25px;
   height: 360px;
   margin-bottom: 30px;
 
   tr th {
     text-align: left;
-    border-bottom: 1pt solid white;
+    border-bottom: 1pt solid #fff;
   }
 }
 

--- a/mtp_api/templates/.gitignore
+++ b/mtp_api/templates/.gitignore
@@ -1,1 +1,0 @@
-govuk_template

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=11.1.0
+money-to-prisoners-common~=11.3.0
 
 psycopg2-binary>=2.8.4,<2.9
 djangorestframework>=3.9.1,<3.10.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=11.1.0
+money-to-prisoners-common[testing]~=11.3.0
 
 -r base.txt
 


### PR DESCRIPTION
The most important part of this PR is upgrading to mtp-common 11.3: 11.x before this one assumed that apps use a single-tree structure for building assets (scripts and stylesheets) whereas `api` actually keeps them in separate folders and does not make bundles.

In future, we want to have the api make asset bundles in the same fashion as other apps so it is not treated a special case.