### PR TITLE
MTP-1863 Remove remaining identifiers from exceptions and attach to sentry metadata

### DIFF
--- a/mtp_api/apps/core/management/commands/delete_zendesk_tickets.py
+++ b/mtp_api/apps/core/management/commands/delete_zendesk_tickets.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
                                     auth=auth, timeout=15)
                     run_again = True
             else:
-                logger.error('Delete old zendesk tickets failed: %s' % response.text)
+                logger.error('Delete old zendesk tickets failed', {'response_body': response.text})
 
             if not run_again:
                 break

--- a/mtp_api/apps/core/management/commands/delete_zendesk_tickets.py
+++ b/mtp_api/apps/core/management/commands/delete_zendesk_tickets.py
@@ -38,7 +38,10 @@ class Command(BaseCommand):
                                     auth=auth, timeout=15)
                     run_again = True
             else:
-                logger.error('Delete old zendesk tickets failed', {'response_body': response.text})
+                logger.error(
+                    'Delete old zendesk tickets failed: %(response_body)s',
+                    {'response_body': response.text}
+                )
 
             if not run_again:
                 break

--- a/mtp_api/apps/core/management/commands/run_scheduled_commands.py
+++ b/mtp_api/apps/core/management/commands/run_scheduled_commands.py
@@ -22,8 +22,6 @@ class Command(BaseCommand):
                         if locked_command.is_scheduled():
                             locked_command.run()
                 except DatabaseError:
-                    logger.warning(
-                        'Scheduled command "%s" failed to run due to database error' % command
-                    )
+                    logger.warning('Scheduled command "%s" failed to run due to database error', command)
                 except Exception:
-                    logger.exception('Scheduled command "%s" failed to run' % command)
+                    logger.exception('Scheduled command "%s" failed to run', command)

--- a/mtp_api/apps/core/models.py
+++ b/mtp_api/apps/core/models.py
@@ -41,12 +41,12 @@ class ScheduledCommand(models.Model):
         return self.arg_string.split(' ') if self.arg_string else []
 
     def run(self):
-        logger.info('Running scheduled command "%s"' % (self))
+        logger.info('Running scheduled command "%s"', self)
         self.update_next_execution()
         self.save()
         start = pc()
         call_command(self.name, *self.get_args())
-        logger.info('Completed scheduled command "%s" in %ss' % (self, pc() - start))
+        logger.info('Completed scheduled command "%s" in %ss', self, pc() - start)
         if self.delete_after_next:
             self.delete()
 

--- a/mtp_api/apps/core/templatetags/tick_charts.py
+++ b/mtp_api/apps/core/templatetags/tick_charts.py
@@ -33,7 +33,7 @@ def get_zero(value):
         return datetime.timedelta()
     if isinstance(value, (int, float)):
         return 0.0
-    raise ValueError('Cannot determine zero value for a %s' % type(value))
+    raise ValueError('Cannot determine zero value', {'type': type(value)})
 
 
 @register.inclusion_tag('core/tick-chart.html')

--- a/mtp_api/apps/core/views.py
+++ b/mtp_api/apps/core/views.py
@@ -255,7 +255,7 @@ class RecreateTestDataView(AdminViewMixin, FormView):
             },
             action_flag=CHANGE_LOG_ENTRY,
         )
-        logger.info('User "%(username)s" reset data for testing using "%(scenario)s" scenario' % {
+        logger.info('User "%(username)s" reset data for testing using "%(scenario)s" scenario', {
             'username': self.request.user.username,
             'scenario': scenario,
         })

--- a/mtp_api/apps/credit/management/commands/create_prisoner_credit_notices.py
+++ b/mtp_api/apps/credit/management/commands/create_prisoner_credit_notices.py
@@ -37,11 +37,11 @@ class Command(BaseCommand):
         try:
             prison = Prison.objects.get(pk=prison)
         except Prison.DoesNotExist:
-            raise CommandError('Prison %s does not exist' % prison)
+            raise CommandError('Prison does not exist', {'prison_nomis_id', prison})
         if date:
             date = parse_date(date)
             if not date:
-                raise CommandError('Date %s cannot be parsed, use YYYY-MM-DD format' % date)
+                raise CommandError('Date cannot be parsed, use YYYY-MM-DD format', {'date_string': date})
         else:
             date = now().date() - datetime.timedelta(days=1)
         date_range = (make_aware(datetime.datetime.combine(date, datetime.time.min)),

--- a/mtp_api/apps/credit/models.py
+++ b/mtp_api/apps/credit/models.py
@@ -157,13 +157,14 @@ class Credit(TimeStampedModel):
 
         if not self.prisoner_profile:
             logger.info(
-                'Could not create PrisonerProfile for credit because Credit lacked either a prison or '
-                'prisoner name',
+                'Could not create PrisonerProfile for credit %(credit_instance)s '
+                'because Credit lacked either a prison or prisoner name',
                 {'credit_instance': self}
             )
         if not self.sender_profile:
             logger.info(
-                'Could not create SenderProfile for credit because Credit lacked necessary information',
+                'Could not create SenderProfile for credit %(credit_instance)s '
+                'because Credit lacked necessary information',
                 {'credit_instance': self}
             )
 
@@ -484,8 +485,9 @@ def update_prison_for_credit(instance, created, **kwargs):
             instance.prison = location.prison
             instance.save()
         except PrisonerLocation.MultipleObjectsReturned:
-            logger.error('Prisoner location is not unique', {
-                'prisoner_number': instance.prisoner_number, 'prisoner_dob': instance.prisoner_dob
+            logger.error('Prisoner location is not unique for %(prisoner_number)s %(prisoner_dob)s', {
+                'prisoner_number': instance.prisoner_number,
+                'prisoner_dob': instance.prisoner_dob,
             })
         except PrisonerLocation.DoesNotExist:
             pass

--- a/mtp_api/apps/credit/models.py
+++ b/mtp_api/apps/credit/models.py
@@ -157,14 +157,14 @@ class Credit(TimeStampedModel):
 
         if not self.prisoner_profile:
             logger.info(
-                'Could not create PrisonerProfile for credit %s because Credit lacked either a prison or '
+                'Could not create PrisonerProfile for credit because Credit lacked either a prison or '
                 'prisoner name',
-                self
+                {'credit_instance': self}
             )
         if not self.sender_profile:
             logger.info(
-                'Could not create SenderProfile for credit %s because Credit lacked necessary information',
-                self
+                'Could not create SenderProfile for credit because Credit lacked necessary information',
+                {'credit_instance': self}
             )
 
     def update_profiles_on_failed_state(self):
@@ -484,9 +484,9 @@ def update_prison_for_credit(instance, created, **kwargs):
             instance.prison = location.prison
             instance.save()
         except PrisonerLocation.MultipleObjectsReturned:
-            logger.error('Prisoner location is not unique for %s %s' % (
-                instance.prisoner_number, instance.prisoner_dob
-            ))
+            logger.error('Prisoner location is not unique', {
+                'prisoner_number': instance.prisoner_number, 'prisoner_dob': instance.prisoner_dob
+            })
         except PrisonerLocation.DoesNotExist:
             pass
 

--- a/mtp_api/apps/credit/tests/test_views/test_credit_list/__init__.py
+++ b/mtp_api/apps/credit/tests/test_views/test_credit_list/__init__.py
@@ -194,7 +194,7 @@ class CreditListTestCase(
                     return datetime.datetime.strptime(date, date_format)
                 except (ValueError, TypeError):
                     continue
-            raise ValueError('Cannot parse date %s' % date)
+            raise ValueError('Cannot parse date', {'date': date})
 
         received_at__gte, received_at__lt = filters.get('received_at__gte'), filters.get('received_at__lt')
         received_at__gte = parse_date(received_at__gte) if received_at__gte else None

--- a/mtp_api/apps/mtp_auth/management/commands/send_account_request_emails.py
+++ b/mtp_api/apps/mtp_auth/management/commands/send_account_request_emails.py
@@ -45,7 +45,9 @@ class Command(BaseCommand):
             if admins:
                 self.email_admins(admins, role, names)
             else:
-                logger.error('No active user admins for %s in %s' % (role.name, prison.name))
+                logger.error(
+                    'No active user admins for role in prison', {'role_name': role.name, 'prison_name': prison.name}
+                )
 
     def find_admins(self, role, prison):
         admins = role.key_group.user_set.filter(

--- a/mtp_api/apps/mtp_auth/management/commands/send_account_request_emails.py
+++ b/mtp_api/apps/mtp_auth/management/commands/send_account_request_emails.py
@@ -46,7 +46,8 @@ class Command(BaseCommand):
                 self.email_admins(admins, role, names)
             else:
                 logger.error(
-                    'No active user admins for role in prison', {'role_name': role.name, 'prison_name': prison.name}
+                    'No active user admins for role in prison for %(role_name)s in %(prison_name)s',
+                    {'role_name': role.name, 'prison_name': prison.name}
                 )
 
     def find_admins(self, role, prison):

--- a/mtp_api/apps/mtp_auth/validators.py
+++ b/mtp_api/apps/mtp_auth/validators.py
@@ -37,7 +37,7 @@ class ApplicationRequestValidator(OAuth2Validator):
             user = None
 
         if user and FailedLoginAttempt.objects.is_locked_out(user, client):
-            logger.info('User "%s" is locked out' % username)
+            logger.info('User "%s" is locked out', username)
             raise LockedOutError(request=request)
 
         valid = super().validate_user(
@@ -51,7 +51,7 @@ class ApplicationRequestValidator(OAuth2Validator):
             user_logged_in.send(sender=user.__class__, request=request, user=user)
             return True
         elif user:
-            logger.info('User "%s" failed login' % username)
+            logger.info('User "%s" failed login', username)
             FailedLoginAttempt.objects.add_failed_attempt(user, client)
             if FailedLoginAttempt.objects.is_lockout_imminent(user, client):
                 raise LockoutImminentError(request=request)

--- a/mtp_api/apps/notification/management/commands/send_notification_report.py
+++ b/mtp_api/apps/notification/management/commands/send_notification_report.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             try:
                 validate_email(email)
             except ValidationError:
-                raise CommandError(f'"{email}" is not valid email address')
+                raise CommandError('Email is not valid email address', {'email': email})
 
         codes = options['rules'] or RULES.keys()
         rules = [RULES[code] for code in codes]

--- a/mtp_api/apps/performance/prediction.py
+++ b/mtp_api/apps/performance/prediction.py
@@ -107,9 +107,9 @@ def train_curve(key, x, y):
     old_params = curve.params.copy()
     curve.optimise(curve.params, x, y)
     if np.array_equal(old_params, curve.params):
-        logger.info(f'Curve {key} already optimised')
+        logger.info('Curve %(key)s already optimised', {'key': key})
     else:
-        logger.info(f'Optimised {key} curve: {curve}')
+        logger.info('Optimised %(key)s curve: %(curve)s', {'key': key, 'curve': curve})
     curve.save_params(key)
     return curve
 

--- a/mtp_api/apps/performance/updaters.py
+++ b/mtp_api/apps/performance/updaters.py
@@ -59,7 +59,7 @@ class BaseUpdater:
 
     def run(self):
         if self._skip():
-            logger.warning('Performance platform update skipped for %s' % self.resource)
+            logger.warning('Performance platform update skipped', {'resource': self.resource})
             return
         govuk_timestamp = self.timestamp.replace(tzinfo=timezone.utc).isoformat()
         self.data.update(
@@ -80,8 +80,8 @@ class BaseUpdater:
         )
         if response.status_code != 200:
             logger.error(
-                'Performance platform update failed for %s: %s'
-                % (self.resource, response.json())
+                'Performance platform update failed',
+                {'resource': self.resource, 'response_payload': response.json()}
             )
 
 

--- a/mtp_api/apps/performance/updaters.py
+++ b/mtp_api/apps/performance/updaters.py
@@ -59,7 +59,7 @@ class BaseUpdater:
 
     def run(self):
         if self._skip():
-            logger.warning('Performance platform update skipped', {'resource': self.resource})
+            logger.warning('Performance platform update skipped for %(resource)s', {'resource': self.resource})
             return
         govuk_timestamp = self.timestamp.replace(tzinfo=timezone.utc).isoformat()
         self.data.update(
@@ -80,7 +80,7 @@ class BaseUpdater:
         )
         if response.status_code != 200:
             logger.error(
-                'Performance platform update failed',
+                'Performance platform update failed for %(resource)s: %(response_payload)r',
                 {'resource': self.resource, 'response_payload': response.json()}
             )
 

--- a/mtp_api/apps/prison/forms.py
+++ b/mtp_api/apps/prison/forms.py
@@ -40,9 +40,9 @@ class PrisonerBalanceUploadForm(forms.Form):
             # and has no decimal places (indicates malformed file)
             numerator, denomiator = amount_pence.as_integer_ratio()
             if numerator <= 0:
-                raise ValueError(f'Negative balance {amount}')
+                raise ValueError('Negative balance', {'amount': amount})
             if denomiator != 1:
-                raise ValueError(f'Cannot turn {amount} into pence')
+                raise ValueError('Cannot turn amount into pence', {'amount': amount})
             balances.append({
                 'prisoner_number': prisoner_number,
                 'amount': int(amount_pence),

--- a/mtp_api/apps/prison/utils.py
+++ b/mtp_api/apps/prison/utils.py
@@ -15,23 +15,30 @@ def fetch_prisoner_location_from_nomis(prisoner_location: PrisonerLocation) -> O
         new_location = nomis.get_location(prisoner_location.prisoner_number)
         if not new_location:
             logger.error(
-                'Malformed response from nomis when looking up prisoner location for prisoner',
+                'Malformed response from NOMIS when looking up prisoner location for %(prisoner_number)s',
                 {'prisoner_number': prisoner_location.prisoner_number}
             )
             return None
         new_prison = Prison.objects.get(nomis_id=new_location['nomis_id'])
     except requests.RequestException:
         logger.error(
-            'Cannot look up prisoner location for prisoner in NOMIS',
+            'Cannot look up prisoner location for %(prisoner_number)s in NOMIS',
             {'prisoner_number': prisoner_location.prisoner_number}
         )
         return None
     except Prison.DoesNotExist:
-        logger.error('Cannot find prison in Prison table', {'nomis_id': new_location['nomis_id']})
+        logger.error(
+            'Cannot find %(nomis_id)s in Prison table',
+            {'nomis_id': new_location['nomis_id']}
+        )
         return None
     else:
         logger.info(
-            f'Location fetched from nomis of {prisoner_location.prisoner_number} is {new_prison.nomis_id}'
+            'Location fetched from nomis of %(prisoner_number)s is %(prison_nomis_id)s',
+            {
+                'prisoner_number': prisoner_location.prisoner_number,
+                'prison_nomis_id': new_prison.nomis_id,
+            }
         )
         # This update will only persist in python space. It is NOT committed to the database
         # This is because we should be calling credit_prisons_need_updating on any update to PrisonerLocation and that

--- a/mtp_api/apps/prison/utils.py
+++ b/mtp_api/apps/prison/utils.py
@@ -10,20 +10,24 @@ logger = logging.getLogger('mtp')
 
 
 def fetch_prisoner_location_from_nomis(prisoner_location: PrisonerLocation) -> Optional[PrisonerLocation]:
+    new_location = None
     try:
         new_location = nomis.get_location(prisoner_location.prisoner_number)
         if not new_location:
             logger.error(
-                'Malformed response from nomis when looking up prisoner location for '
-                f'{prisoner_location.prisoner_number}'
+                'Malformed response from nomis when looking up prisoner location for prisoner',
+                {'prisoner_number': prisoner_location.prisoner_number}
             )
             return None
         new_prison = Prison.objects.get(nomis_id=new_location['nomis_id'])
     except requests.RequestException:
-        logger.error(f'Cannot look up prisoner location for {prisoner_location.prisoner_number} in NOMIS')
+        logger.error(
+            'Cannot look up prisoner location for prisoner in NOMIS',
+            {'prisoner_number': prisoner_location.prisoner_number}
+        )
         return None
     except Prison.DoesNotExist:
-        logger.error(f'Cannot find prison matching {new_location["nomis_id"]} in Prison table')
+        logger.error('Cannot find prison in Prison table', {'nomis_id': new_location['nomis_id']})
         return None
     else:
         logger.info(

--- a/mtp_api/apps/security/managers.py
+++ b/mtp_api/apps/security/managers.py
@@ -136,7 +136,7 @@ class SenderProfileManager(models.Manager):
         elif hasattr(credit, 'payment'):
             sender_profile = self._create_or_update_for_debit_card(credit)
         else:
-            logger.error('Credit does not have a payment nor transaction', {'credit_id': credit.pk})
+            logger.error('Credit %(credit_id)s does not have a payment nor transaction', {'credit_id': credit.pk})
             sender_profile = self.get_or_create_anonymous_sender()
 
         # Annoyingly we still have to add this resolution clause for test setup, due to the fact that our test setup

--- a/mtp_api/apps/security/managers.py
+++ b/mtp_api/apps/security/managers.py
@@ -136,7 +136,7 @@ class SenderProfileManager(models.Manager):
         elif hasattr(credit, 'payment'):
             sender_profile = self._create_or_update_for_debit_card(credit)
         else:
-            logger.error(f'Credit {credit.pk} does not have a payment nor transaction')
+            logger.error('Credit does not have a payment nor transaction', {'credit_id': credit.pk})
             sender_profile = self.get_or_create_anonymous_sender()
 
         # Annoyingly we still have to add this resolution clause for test setup, due to the fact that our test setup

--- a/mtp_api/apps/security/views_admin.py
+++ b/mtp_api/apps/security/views_admin.py
@@ -91,7 +91,7 @@ class CheckReportAdminView(BaseAdminReportView):
                     row['pending_amount'] += amount
                 else:
                     logger.warning(
-                        f'Unexpected grouped check status: status={status} triggered_rules={triggered_rules}'
+                        'Unexpected grouped check status', {'status': status, 'triggered_rules': triggered_rules}
                     )
             grouped_rows.append(row)
 

--- a/mtp_api/apps/security/views_admin.py
+++ b/mtp_api/apps/security/views_admin.py
@@ -91,7 +91,8 @@ class CheckReportAdminView(BaseAdminReportView):
                     row['pending_amount'] += amount
                 else:
                     logger.warning(
-                        'Unexpected grouped check status', {'status': status, 'triggered_rules': triggered_rules}
+                        'Unexpected grouped check status %(status)s with %(triggered_rules)s',
+                        {'status': status, 'triggered_rules': triggered_rules}
                     )
             grouped_rows.append(row)
 

--- a/mtp_api/apps/transaction/views.py
+++ b/mtp_api/apps/transaction/views.py
@@ -74,8 +74,10 @@ class TransactionView(
         try:
             return self.partial_update(request, *args, **kwargs)
         except InvalidCreditStateException as e:
-            logger.warning('Some transactions failed to update: [%s]' %
-                           ', '.join(map(str, e.conflict_ids)))
+            logger.warning(
+                'Some transactions failed to update',
+                {'transaction_id_list': e.conflict_ids}
+            )
             return Response(
                 data={
                     'errors': [

--- a/mtp_api/apps/transaction/views.py
+++ b/mtp_api/apps/transaction/views.py
@@ -75,7 +75,7 @@ class TransactionView(
             return self.partial_update(request, *args, **kwargs)
         except InvalidCreditStateException as e:
             logger.warning(
-                'Some transactions failed to update',
+                'Some transactions failed to update: %(transaction_id_list)r',
                 {'transaction_id_list': e.conflict_ids}
             )
             return Response(

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=11.3.0
+money-to-prisoners-common~=11.4.0
 
 psycopg2-binary>=2.8.4,<2.9
 djangorestframework>=3.9.1,<3.10.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=11.3.0
+money-to-prisoners-common[testing]~=11.4.0
 
 -r base.txt
 


### PR DESCRIPTION
Jira: https://dsdmoj.atlassian.net/browse/MTP-1863

* Moved dynamic fields out of logger.error/warning and exceptions to allow for sentry to deduplicate

Note that i've left any exceptions propagate to the UI/API and do not touch Sentry alone (`ValidationError`, `InvalidStateForUpdateException` etc)

Depends on [common#419](https://github.com/ministryofjustice/money-to-prisoners-common/pull/419)