### PR TITLE
'send_account_request_emails' works with requests without prison

### DIFF
--- a/mtp_api/apps/mtp_auth/management/commands/send_account_request_emails.py
+++ b/mtp_api/apps/mtp_auth/management/commands/send_account_request_emails.py
@@ -34,7 +34,11 @@ class Command(BaseCommand):
             names=ArrayAgg(Concat('first_name', models.Value(' '), 'last_name'))
         )
         for group in grouped_requests:
-            prison = Prison.objects.get(pk=group['prison'])
+            if group['prison']:
+                prison = Prison.objects.get(pk=group['prison'])
+            else:
+                prison = None
+
             role = Role.objects.get(pk=group['role'])
             names = group['names']
             admins = self.find_admins(role, prison)
@@ -46,12 +50,16 @@ class Command(BaseCommand):
     def find_admins(self, role, prison):
         admins = role.key_group.user_set.filter(
             is_active=True, is_superuser=False
-        ).filter(groups__name='UserAdmin').filter(prisonusermapping__prisons=prison)
+        ).filter(groups__name='UserAdmin')
+
+        # 'security' requests are sent to all UserAdmins/FIU regardless of prison
+        if role.name != 'security':
+            admins = admins.filter(prisonusermapping__prisons=prison)
+
         return list(admins)
 
     def email_admins(self, admins, role, prison, names):
         service_name = role.application.name.lower()
-        prison_name = prison.short_name
         send_email(
             [admin.email for admin in admins],
             'mtp_auth/new_account_requests.txt',
@@ -60,7 +68,6 @@ class Command(BaseCommand):
             }),
             context={
                 'service_name': service_name,
-                'prison_name': prison_name,
                 'names': names,
                 'login_url': role.login_url,
             },

--- a/mtp_api/apps/mtp_auth/management/commands/send_account_request_emails.py
+++ b/mtp_api/apps/mtp_auth/management/commands/send_account_request_emails.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
             names = group['names']
             admins = self.find_admins(role, prison)
             if admins:
-                self.email_admins(admins, role, prison, names)
+                self.email_admins(admins, role, names)
             else:
                 logger.error('No active user admins for %s in %s' % (role.name, prison.name))
 
@@ -58,7 +58,7 @@ class Command(BaseCommand):
 
         return list(admins)
 
-    def email_admins(self, admins, role, prison, names):
+    def email_admins(self, admins, role, names):
         service_name = role.application.name.lower()
         send_email(
             [admin.email for admin in admins],

--- a/mtp_api/apps/mtp_auth/tests/test_account_request_emails.py
+++ b/mtp_api/apps/mtp_auth/tests/test_account_request_emails.py
@@ -99,8 +99,8 @@ class AccountRequestEmailTestCase(TestCase):
             # ('test_name', 'role_name', 'prison_id', 'expected_admins')
             ('prison-clerk-prison-1', 'prison-clerk', 'IXB', ['test-prison-1-ua']),
             ('prison-clerk-prison-2', 'prison-clerk', 'INP', ['test-prison-2-ua']),
-            ('security-prison-1', 'security', 'IXB', ['security-user-admin', 'prison-security-ua']),
-            ('security-no-prison', 'security', None, ['security-user-admin', 'prison-security-ua']),
+            ('security-prison-1', 'security', 'IXB', ['security-fiu-0', 'security-fiu-100', 'security-fiu-101']),
+            ('security-no-prison', 'security', None, ['security-fiu-0', 'security-fiu-100', 'security-fiu-101']),
         ]
         for test_name, role_name, prison_id, expected_admins in cases:
             with self.subTest(test_name):

--- a/mtp_api/apps/mtp_auth/tests/test_account_request_emails.py
+++ b/mtp_api/apps/mtp_auth/tests/test_account_request_emails.py
@@ -4,13 +4,13 @@ from unittest import mock
 
 from django.core.management import call_command
 from django.test import TestCase
-from django.utils.text import slugify
 from django.utils.timezone import now, localtime
 from faker import Faker
 from model_mommy import mommy
 
 from core.tests.utils import make_test_users, make_test_user_admins
-from mtp_auth.models import AccountRequest, Role
+from mtp_auth.management.commands.send_account_request_emails import Command
+from mtp_auth.models import AccountRequest, PrisonUserMapping, Role
 from prison.models import Prison
 
 fake = Faker(locale='en_GB')
@@ -24,48 +24,87 @@ class AccountRequestEmailTestCase(TestCase):
         make_test_users()
         make_test_user_admins()
 
-    def test_emails_correctly_grouped(self):
-        from mtp_auth.management.commands.send_account_request_emails import Command
+    def _make_account_request(self, role, prison, created):
+        return mommy.make(
+            AccountRequest,
+            role=role,
+            prison=prison,
+            created=created,
+            first_name=fake.first_name(),
+            last_name=fake.last_name(),
+            email=fake.safe_email(),
+        )
 
+    def test_emails_correctly_grouped(self):
         today = localtime(now()).replace(hour=0, minute=0, second=0, microsecond=0)
 
         def yesterday_sometime():
             return today - datetime.timedelta(seconds=random.randrange(1, 86400))
 
-        role = Role.objects.get(name='prison-clerk')
+        prison_clerk_role = Role.objects.get(name='prison-clerk')
         prisons = list(Prison.objects.all())
         expected_names = {}
         for prison in prisons:
             expected_names[prison] = set()
             for _ in range(3):
-                request = mommy.make(
-                    AccountRequest, created=yesterday_sometime(),
-                    prison=prison, role=role,
-                    first_name=fake.first_name(), last_name=fake.last_name(), email=fake.safe_email()
+                # Request triggering email
+                request = self._make_account_request(
+                    role=prison_clerk_role,
+                    prison=prison,
+                    created=yesterday_sometime(),
                 )
                 expected_names[prison].add('%s %s' % (request.first_name, request.last_name))
-                mommy.make(
-                    AccountRequest, created=yesterday_sometime() - datetime.timedelta(days=1),
-                    prison=prison, role=role,
-                    first_name=fake.first_name(), last_name=fake.last_name(), email=fake.safe_email()
+                # Requests *not* triggering emails
+                self._make_account_request(
+                    role=prison_clerk_role,
+                    prison=prison,
+                    created=yesterday_sometime() - datetime.timedelta(days=1),  # 2 days ago
                 )
-                mommy.make(
-                    AccountRequest, created=yesterday_sometime() + datetime.timedelta(days=1),
-                    prison=prison, role=role,
-                    first_name=fake.first_name(), last_name=fake.last_name(), email=fake.safe_email()
+                self._make_account_request(
+                    role=prison_clerk_role,
+                    prison=prison,
+                    created=yesterday_sometime() + datetime.timedelta(days=1),  # Today
                 )
+
+        # Account Requests for 'security' role have no prison
+        security_role = Role.objects.get(name='security')
+        security_request = self._make_account_request(
+            role=security_role,
+            prison=None,
+            created=yesterday_sometime(),
+        )
+        expected_names[None] = set()
+        expected_names[None].add('%s %s' % (security_request.first_name, security_request.last_name))
 
         with mock.patch.object(Command, 'email_admins') as method:
             call_command('send_account_request_emails')
-        self.assertEqual(method.call_count, 2)
+        self.assertEqual(method.call_count, 3)
         for call in method.call_args_list:
             admins, role, prison, names = call[0]
-            self.assertTrue(all(
-                (
-                    admin.groups.filter(pk=role.key_group_id).exists() and
-                    admin.prisonusermapping.prisons.filter(pk=prison.pk).exists()
-                )
-                for admin in admins
-            ))
-            self.assertEqual(set(admin.username for admin in admins), {'test-%s-ua' % slugify(prison.name)})
             self.assertSetEqual(set(names), expected_names[prison])
+
+    def test_find_admins(self):
+        command = Command()
+
+        cases = [
+            # ('test_name', 'role_name', 'prison_id', 'expected_admins')
+            ('prison-clerk-prison-1', 'prison-clerk', 'IXB', ['test-prison-1-ua']),
+            ('prison-clerk-prison-2', 'prison-clerk', 'INP', ['test-prison-2-ua']),
+            ('security-prison-1', 'security', 'IXB', ['security-user-admin', 'prison-security-ua']),
+            ('security-no-prison', 'security', None, ['security-user-admin', 'prison-security-ua']),
+        ]
+        for test_name, role_name, prison_id, expected_admins in cases:
+            with self.subTest(test_name):
+                prison = Prison.objects.get(nomis_id=prison_id) if prison_id else None
+                role = Role.objects.get(name=role_name)
+
+                admins = command.find_admins(role, prison)
+
+                # Test correct admins/names
+                admin_names = [admin.username for admin in admins]
+                self.assertEqual(set(admin_names), set(expected_admins))
+
+                # Tests all admins are in the Role's key Group
+                for admin in admins:
+                    groups = admin.groups.all()
+                    self.assertIn(role.key_group, groups)


### PR DESCRIPTION
'security' account requests are not prison-specific.
These 'security' account requests are emailed to all the 'security' `UserAdmins`
(FIU), regardless of which prisons are associated to these `UserAdmins`.

The test for this command have been improved to separate the test for the
`find_admins()` method from the test which checks correct admins are emailed.

**NOTE**: The `mtp_auth/new_account_requests.(html|txt)` templates don't seem
to use the `prison_name` in the context so I've removed it.