### PR TITLE
Make 'security' user a UserAdmin makes them FIU

### DIFF
--- a/mtp_api/apps/mtp_auth/serializers.py
+++ b/mtp_api/apps/mtp_auth/serializers.py
@@ -246,12 +246,12 @@ class UserSerializer(serializers.ModelSerializer):
             updated_user.applicationusermapping_set.all().delete()
             updated_user.groups.clear()
 
-            if make_user_admin:
-                self._make_user_admin(updated_user)
-
             ApplicationUserMapping.objects.create(user=updated_user, application=role.application)
             for group in role.groups:
                 updated_user.groups.add(group)
+
+            if make_user_admin:
+                self._make_user_admin(updated_user)
         elif was_user_admin != make_user_admin:
             if make_user_admin:
                 self._make_user_admin(updated_user)

--- a/mtp_api/apps/mtp_auth/tests/test_views.py
+++ b/mtp_api/apps/mtp_auth/tests/test_views.py
@@ -1560,6 +1560,27 @@ class UpdateUserTestCase(AuthBaseTestCase):
         ).all()
         self.assertEqual(set(current_prisons), set(updated_prisons))
 
+    def test_update_user_passing_role_adding_fiu_group_also_adds_user_admin_group(self):
+        """
+        Test user added to FIU group also has UserAdmin group
+
+        As of MTP-1824, FIU is managing all Security users through the UserAdmin group
+        """
+        user = self.security_users[1]
+        requesting_user = self.security_uas[0]
+        user_data = {
+            'user_admin': True,
+            'role': 'security',
+        }
+
+        self.assertUserUpdated(requesting_user, user.username, user_data)
+
+        updated_user = User.objects.get(username=user.username)
+        self.assertSequenceEqual(
+            updated_user.groups.order_by('name').values_list('name', flat=True),
+            ['FIU', 'Security', 'UserAdmin']
+        )
+
     def test_updated_user_removing_fiu_group_also_removes_user_admin_group(self):
         """
         Test user removed from FIU group also has UserAdmin group


### PR DESCRIPTION
In the context of intelligence tool, FIU users are equivalent to user admins.
If a security user is in `FIU` group they would also be in `UserAdmin`
group and vice versa.

The helper method `_make_user_admin()` was called just after the user's
groups were clear which meant the user was not added to `FIU` group as
intended.

See comment with more links to code: https://github.com/ministryofjustice/money-to-prisoners-api/pull/647#discussion_r615735071