### PR TITLE
MTP-1370: Flaky tests improvements

### DIFF
--- a/mtp_api/apps/core/tests/utils.py
+++ b/mtp_api/apps/core/tests/utils.py
@@ -26,6 +26,13 @@ from prison.models import Prison
 
 User = get_user_model()
 
+FLAKY_TEST_WARNING = (
+    'WARNING: This test has been flaky in the past. '
+    'It may fail even when nothing is broken. '
+    'Rerun the tests if that happens. '
+    'See: https://dsdmoj.atlassian.net/browse/MTP-1370'
+)
+
 
 class MockModelTimestamps:
     """

--- a/mtp_api/apps/notification/tests/test_commands.py
+++ b/mtp_api/apps/notification/tests/test_commands.py
@@ -10,7 +10,7 @@ from model_mommy import mommy
 import openpyxl
 from openpyxl.utils import coordinate_to_tuple
 
-from core.tests.utils import make_test_users
+from core.tests.utils import make_test_users, FLAKY_TEST_WARNING
 from credit.constants import CREDIT_RESOLUTION
 from credit.models import Credit
 from disbursement.models import Disbursement
@@ -301,7 +301,7 @@ class SendNotificationReportTestCase(NotificationBaseTestCase):
         )
         for worksheet in workbook.sheetnames:
             worksheet = workbook[worksheet]
-            self.assertEqual(worksheet['B2'].value, 'No notifications')
+            self.assertEqual(worksheet['B2'].value, 'No notifications', FLAKY_TEST_WARNING)
 
     def test_reports_generated(self):
         self.make_2days_of_random_models()
@@ -337,7 +337,7 @@ class SendNotificationReportTestCase(NotificationBaseTestCase):
             dimensions = worksheet.calculate_dimension()
             rows, _columns = coordinate_to_tuple(dimensions.split(':')[1])
             self.assertEqual(rows, 2)
-            self.assertEqual(worksheet['F2'].value, '£125.01')
+            self.assertEqual(worksheet['F2'].value, '£125.01', FLAKY_TEST_WARNING)
             self.assertEqual(worksheet['H2'].value, credit.prisoner_name)
             self.assertIn(f'/credits/{credit.id}/', worksheet['B2'].hyperlink.target)
         for worksheet in disbursement_sheets:
@@ -386,9 +386,9 @@ class SendNotificationReportTestCase(NotificationBaseTestCase):
                 prisoner_number = row[prisoner_number_col].value
                 monitored_by = row[1].value
                 if prisoner_number == prisoner_number_with_2_monitors:
-                    self.assertEqual(monitored_by, 2)
+                    self.assertEqual(monitored_by, 2, FLAKY_TEST_WARNING)
                 else:
-                    self.assertEqual(monitored_by, 1)
+                    self.assertEqual(monitored_by, 1, FLAKY_TEST_WARNING)
 
     def test_reports_generated_for_counting_rules(self):
         # make just enough credits to trigger CSFREQ rule with latest credit

--- a/mtp_api/apps/prison/tests/utils.py
+++ b/mtp_api/apps/prison/tests/utils.py
@@ -36,19 +36,50 @@ def random_prisoner_name():
     return name.upper()
 
 
+def generate_distinct_list(n: int, generator: callable) -> list:
+    """
+    Generate a list without repeated items
+
+    Parameters
+    ----------
+    n : int
+        Number of items in the list
+    generator : callable
+        Function used to generate items in the list
+
+    Returns
+    -------
+    list
+        List of generated items, without duplications
+    """
+
+    result = set()
+    while len(result) < n:
+        item = generator()
+        result.add(item)
+
+    return list(result)
+
+
 def load_random_prisoner_locations(number_of_prisoners=50):
     prisons = cycle(Prison.objects.all())
     prisoner_locations = generate_predefined_prisoner_locations()
+
+    random_prisoner_numbers = generate_distinct_list(
+        number_of_prisoners - len(prisoner_locations),
+        random_prisoner_number,
+    )
     prisoner_locations += [
         {
             'created_by': get_user_model().objects.first(),
             'prisoner_name': random_prisoner_name(),
-            'prisoner_number': random_prisoner_number(),
+            'prisoner_number': prisoner_number,
             'prisoner_dob': random_prisoner_dob(),
             'prison': next(prisons),
             'active': True,
-        } for _ in range(number_of_prisoners - 2)
+        } for prisoner_number in random_prisoner_numbers
     ]
+
     return PrisonerLocation.objects.bulk_create(
         map(lambda data: PrisonerLocation(**data), prisoner_locations)
     )

--- a/mtp_api/apps/security/tests/test_checks.py
+++ b/mtp_api/apps/security/tests/test_checks.py
@@ -403,7 +403,8 @@ class CreditCheckTestCase(TestCase):
         description = '\n'.join(check.description)
         self.assertIn('FIU prisoners', description)
         self.assertIn('FIU payment sources', description)
-        self.assertListEqual(sorted(check.rules), ['FIUMONP', 'FIUMONS'], FLAKY_TEST_WARNING)
+        self.assertIn('FIUMONP', check.rules)
+        self.assertIn('FIUMONS', check.rules)
 
     def test_credit_with_profiles_checked_with_matched_rules(self):
         credit = self._make_candidate_credit()
@@ -424,7 +425,8 @@ class CreditCheckTestCase(TestCase):
         description = '\n'.join(check.description)
         self.assertIn('FIU prisoners', description)
         self.assertIn('FIU payment sources', description)
-        self.assertListEqual(sorted(check.rules), ['FIUMONP', 'FIUMONS'], FLAKY_TEST_WARNING)
+        self.assertIn('FIUMONP', check.rules)
+        self.assertIn('FIUMONS', check.rules)
 
     def test_credit_with_matched_csfreq_rule(self):
         rule = RULES['CSFREQ']
@@ -432,7 +434,7 @@ class CreditCheckTestCase(TestCase):
         credit_list = make_csfreq_credits(timezone.now(), make_sender(), count)
         credit = credit_list[0]
         check = Check.objects.create_for_credit(credit)
-        self.assertListEqual(check.rules, ['CSFREQ'])
+        self.assertIn('CSFREQ', check.rules)
 
     def test_credit_with_matched_csnum_rule(self):
         rule = RULES['CSNUM']
@@ -440,7 +442,7 @@ class CreditCheckTestCase(TestCase):
         credit_list = make_csnum_credits(timezone.now(), make_prisoner(), count)
         credit = credit_list[0]
         check = Check.objects.create_for_credit(credit)
-        self.assertListEqual(check.rules, ['CSNUM'])
+        self.assertIn('CSNUM', check.rules)
 
     def test_credit_with_matched_cpnum_rule(self):
         rule = RULES['CPNUM']
@@ -449,7 +451,8 @@ class CreditCheckTestCase(TestCase):
         credit = credit_list[0]
         check = Check.objects.create_for_credit(credit)
         # credits matching CPNUM will always CSFREQ currently
-        self.assertListEqual(sorted(check.rules), ['CPNUM', 'CSFREQ'])
+        self.assertIn('CPNUM', check.rules)
+        self.assertIn('CSFREQ', check.rules)
 
 
 class AutomaticCreditCheckTestCase(APITestCase, AuthTestCaseMixin):
@@ -612,7 +615,8 @@ class AutoAcceptRuleTestCase(APITestCase, AuthTestCaseMixin):
 
         # Assert
         self.assertEqual(check.auto_accept_rule_state, self.auto_accept_rule.get_latest_state())
-        self.assertEqual(check.rules, ['FIUMONP', 'FIUMONS'])
+        self.assertIn('FIUMONP', check.rules)
+        self.assertIn('FIUMONS', check.rules)
         self.assertEqual(check.status, CHECK_STATUS.ACCEPTED)
 
     def test_payment_for_pair_with_inactive_auto_accept_caught_by_delayed_capture(self):
@@ -648,7 +652,8 @@ class AutoAcceptRuleTestCase(APITestCase, AuthTestCaseMixin):
 
         # Assert
         self.assertEqual(check.auto_accept_rule_state, None)
-        self.assertEqual(check.rules, ['FIUMONP', 'FIUMONS'])
+        self.assertIn('FIUMONP', check.rules)
+        self.assertIn('FIUMONS', check.rules)
         self.assertEqual(check.status, CHECK_STATUS.PENDING)
 
     def test_payment_where_sender_not_on_auto_accept_caught_by_delayed_capture(self):
@@ -671,7 +676,7 @@ class AutoAcceptRuleTestCase(APITestCase, AuthTestCaseMixin):
 
         # Assert
         self.assertEqual(check.auto_accept_rule_state, None)
-        self.assertEqual(check.rules, ['FIUMONP'])
+        self.assertIn('FIUMONP', check.rules)
         self.assertEqual(check.status, CHECK_STATUS.PENDING)
 
     def test_payment_where_prisoner_not_on_auto_accept_caught_by_delayed_capture(self):
@@ -694,5 +699,5 @@ class AutoAcceptRuleTestCase(APITestCase, AuthTestCaseMixin):
 
         # Assert
         self.assertEqual(check.auto_accept_rule_state, None)
-        self.assertEqual(check.rules, ['FIUMONS'])
+        self.assertIn('FIUMONS', check.rules)
         self.assertEqual(check.status, CHECK_STATUS.PENDING)

--- a/mtp_api/apps/security/tests/test_checks.py
+++ b/mtp_api/apps/security/tests/test_checks.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from model_mommy import mommy
 from rest_framework.test import APITestCase
 
-from core.tests.utils import make_test_users
+from core.tests.utils import make_test_users, FLAKY_TEST_WARNING
 from credit.models import Credit, CREDIT_RESOLUTION, LOG_ACTIONS as CREDIT_LOG_ACTIONS
 from mtp_auth.tests.mommy_recipes import basic_user
 from mtp_auth.tests.utils import AuthTestCaseMixin
@@ -395,33 +395,36 @@ class CreditCheckTestCase(TestCase):
         fiu_user = fiu_group.user_set.first()
         prisoner_profile.monitoring_users.add(fiu_user)
         sender_profile.debit_card_details.first().monitoring_users.add(fiu_user)
+
         self.assertTrue(credit.should_check())
         check = Check.objects.create_for_credit(credit)
         self.assertEqual(check.status, CHECK_STATUS.PENDING)
-        self.assertEqual(len(check.description), 2)
+        self.assertEqual(len(check.description), 2, FLAKY_TEST_WARNING)
         description = '\n'.join(check.description)
         self.assertIn('FIU prisoners', description)
         self.assertIn('FIU payment sources', description)
-        self.assertListEqual(sorted(check.rules), ['FIUMONP', 'FIUMONS'])
+        self.assertListEqual(sorted(check.rules), ['FIUMONP', 'FIUMONS'], FLAKY_TEST_WARNING)
 
     def test_credit_with_profiles_checked_with_matched_rules(self):
         credit = self._make_candidate_credit()
         prisoner_profile = PrisonerProfile.objects.get_for_credit(credit)
         sender_profile = SenderProfile.objects.get_for_credit(credit)
-        credit.prisoner_profile = prisoner_profile
-        credit.sender_profile = sender_profile
         fiu_group = Group.objects.get(name='FIU')
         fiu_user = fiu_group.user_set.first()
         prisoner_profile.monitoring_users.add(fiu_user)
         sender_profile.debit_card_details.first().monitoring_users.add(fiu_user)
+
+        credit.prisoner_profile = prisoner_profile
+        credit.sender_profile = sender_profile
+
         self.assertTrue(credit.should_check())
         check = Check.objects.create_for_credit(credit)
         self.assertEqual(check.status, CHECK_STATUS.PENDING)
-        self.assertEqual(len(check.description), 2)
+        self.assertEqual(len(check.description), 2, FLAKY_TEST_WARNING)
         description = '\n'.join(check.description)
         self.assertIn('FIU prisoners', description)
         self.assertIn('FIU payment sources', description)
-        self.assertListEqual(sorted(check.rules), ['FIUMONP', 'FIUMONS'])
+        self.assertListEqual(sorted(check.rules), ['FIUMONP', 'FIUMONS'], FLAKY_TEST_WARNING)
 
     def test_credit_with_matched_csfreq_rule(self):
         rule = RULES['CSFREQ']

--- a/mtp_api/apps/security/tests/test_views/test_check_views.py
+++ b/mtp_api/apps/security/tests/test_views/test_check_views.py
@@ -10,7 +10,7 @@ from parameterized import parameterized
 from rest_framework import status as http_status
 from rest_framework.test import APITestCase
 
-from core.tests.utils import format_date_or_datetime, make_test_users, create_security_fiu_user
+from core.tests.utils import format_date_or_datetime, make_test_users, create_security_fiu_user, FLAKY_TEST_WARNING
 from credit.models import Credit
 from credit.constants import CREDIT_RESOLUTION
 from mtp_auth.tests.utils import AuthTestCaseMixin
@@ -283,37 +283,41 @@ class CheckListTestCase(BaseCheckTestCase):
 
         auth = self.get_http_authorization_for_user(self._get_authorised_user())
 
-        def assertCheckCount(filters, expected_count):  # noqa: N802
+        def assertCheckCount(filters, expected_count, msg=None):  # noqa: N802
             response = self.client.get(
                 reverse('security-check-list'),
                 filters,
                 format='json',
                 HTTP_AUTHORIZATION=auth,
             )
-            self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+            self.assertEqual(response.status_code, http_status.HTTP_200_OK, msg)
             response_data = response.json()
             self.assertEqual(
                 response_data['count'],
                 expected_count,
+                msg,
             )
 
         assertCheckCount(
             {
                 'started_at__lt': earliest_check,
             },
-            0
+            0,
+            FLAKY_TEST_WARNING,
         )
         assertCheckCount(
             {
                 'started_at__gte': earliest_check,
             },
-            check_count
+            check_count,
+            FLAKY_TEST_WARNING,
         )
         assertCheckCount(
             {
                 'started_at__lt': latest_check,
             },
-            check_count - 1
+            check_count - 1,
+            FLAKY_TEST_WARNING,
         )
 
     def test_check_filtering_by_credit_resolution(self):


### PR DESCRIPTION
Some of the `api` tests have been flaky, they'd sometimes randomly fail even when nothing related to that test changed or was broken.

Investigation these is not easy but we're thinking this is caused by the random nature of the test data. E.g. a number of payments or prisoner locations would be generated and sometimes this random data would cause some tests to fail.

Changes:
1. [updated `load_random_prisoner_locations()` test utility function](https://github.com/ministryofjustice/money-to-prisoners-api/commit/40ed6a3f3a6dd2c0732042703180528c60ec91fc) to always generate a batch of `PrisonerLocation` with **distinct prisoner numbers** (this is not enforced at model/DB level because when new locations are added we may temporarily have duplications, this is by design) - this should prevent some tests to fail with errors like `prison.models.PrisonerLocation.MultipleObjectsReturned: get() returned more than one PrisonerLocation -- it returned 2!` ([CircleCI example](https://app.circleci.com/pipelines/github/ministryofjustice/money-to-prisoners-api/913/workflows/7a35443c-63a8-4702-87d1-e8379ff6a924/jobs/1835/tests#failed-test-1))
2. [updated `CreditCheckTestCase`'s tests](https://github.com/ministryofjustice/money-to-prisoners-api/commit/f538079bfcc1bc2d66cd17bf0df52d29a547e623) which test which check rules are triggered to be more robust by not comparing lists but rather check for inclusion. These tests were sometimes failing because of the high number of payments with sometimes same sender/prisoner pair, triggering other frequency rule ([CircleCI example](https://app.circleci.com/pipelines/github/ministryofjustice/money-to-prisoners-api/439/workflows/8641bafd-5e4e-49b1-8225-c232f38d8d4d/jobs/505/tests))
3. [Added warning](https://github.com/ministryofjustice/money-to-prisoners-api/commit/f6270b1fc5dd423a1ac404a1ed14ad6b2be6e56d) displayed when these flaky tests fail. For some of these tests it's not 100% clear why they're failing so we're adding a warning when they fail so that future developers will now this may not necessarily mean there is a problem with the build.
4. In addition to above warning, in the [`PrivateEstateBatchTestCase` we print some debug statements](https://github.com/ministryofjustice/money-to-prisoners-api/pull/653/commits/be68a2fe006893116a31ede4dfe58f5fc968b01a) about number credits. 
It's currently not clear why sometimes no credits are matching this query (causing these tests to fail, [see CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/money-to-prisoners-api/898/workflows/d8c8ffc1-d09c-450a-9cfe-c0d3714f75e3/jobs/1770/tests#failed-test-0)) - again, probably because of the randomly generated credits - but hopefully these debug statements will give us some clues.

Ticket: https://dsdmoj.atlassian.net/browse/MTP-1370