### PR TITLE
Fix flaky PrivateEstateBatch test

### DIFF
--- a/mtp_api/apps/credit/tests/test_private_estate.py
+++ b/mtp_api/apps/credit/tests/test_private_estate.py
@@ -53,8 +53,10 @@ class PrivateEstateBatchTestCase(AuthTestCaseMixin, APITestCase):
             public_estate_credits = Credit.objects.filter(prison__private_estate=False).filter(creditable)
             public_estate_credits[public_estate_credits.count() // 2:].update(prison=self.private_prison)
 
-        self.latest_date = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        date = Credit.objects.earliest().received_at.replace(hour=0, minute=0, second=0, microsecond=0)
+        self.latest_date = timezone.localtime().replace(hour=0, minute=0, second=0, microsecond=0)
+
+        date = timezone.localtime(Credit.objects.earliest().received_at)
+        date = date.replace(hour=0, minute=0, second=0, microsecond=0)
         while date < self.latest_date:
             end_of_date = date + datetime.timedelta(days=1)
             PrivateEstateBatch.objects.create_batches(date, end_of_date)


### PR DESCRIPTION
This test was sometimes failing because of some of the credits in the
private estate batch had a `received_at` from a different day:

https://app.circleci.com/pipelines/github/ministryofjustice/money-to-prisoners-api/940/workflows/92b6483e-a11c-4a4c-b7b5-0c914670bbd6/jobs/1952

Problem
-------
This was failing when one of the credits had a `received_at` close
to midnight, e.g. 00:30 BST (+01:00).

In the `setUp()` a UTC datetime was used to create the batches, this would
select credits between 00:00 UTC to 23:59 UTC causing the credit above to
mistakenly end into the batch for the previous day (because its
`received_at` was 23:30 UTC)

[The assertion](https://app.circleci.com/pipelines/github/ministryofjustice/money-to-prisoners-api/940/workflows/92b6483e-a11c-4a4c-b7b5-0c914670bbd6/jobs/1952) to check that _all_ returned credits' `received_at`
were in the same date as in the batch date would then fail.

Example:

- Credit 1: 10th May @ 10:00 BST (09:00 UTC)
- Credit 2: 11th May @ 00:30 BST (23:30 UTC of 10th May)

Credit 2 would end up in the batch for the 10th of May but its
`received_at` date is the 11th of May.

Solution
--------
When creating the batches in the `setUp()` use local times instead of
UTC times to generate these batches. This way the query in
`credit.managers.PrivateEstateBatchManager.create_batches()`
should select the credits in the correct time intervals and assign them
to the expected batches.