### PR TITLE
Drop support for Python < 3.8

### DIFF
--- a/.github/workflows/clean-ecr.yml
+++ b/.github/workflows/clean-ecr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   clean-ecr:
     name: Clean ECR
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Backend and internal admin site for [Prisoner Money suite of apps](https://githu
 
 ## Requirements
 
-- Unix-like platform with Python 3.6+ and NodeJS 10 (e.g. via [nvm](https://github.com/nvm-sh/nvm#nvmrc))
+- Unix-like platform with Python 3.8+ and NodeJS 10 (e.g. via [nvm](https://github.com/nvm-sh/nvm#nvmrc))
 - PostgreSQL
 
 ## Developing

--- a/run.py
+++ b/run.py
@@ -3,8 +3,8 @@ if __name__ == '__main__':
     import os
     import sys
 
-    if sys.version_info[0:2] < (3, 6):
-        raise SystemExit('Python 3.6+ is required')
+    if sys.version_info[0:2] < (3, 8):
+        raise SystemExit('Python 3.8+ is required')
 
     root_path = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
We're upgrading `base`/`base-web` images to be based on Ubuntu 20.04 which
comes with Python 3.8.
It makes sense to drop support for anything older.

Also updated GH Workflow to run on newer Ubuntu 20.04 container.

Ticket: https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=79&projectKey=MTP&modal=detail&selectedIssue=MTP-1841