### PR TITLE
Update Performance data on User Satisfaction/Digital Take-up upload

### DIFF
--- a/mtp_api/apps/performance/forms.py
+++ b/mtp_api/apps/performance/forms.py
@@ -162,6 +162,9 @@ class UserSatisfactionUploadForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.records = collections.defaultdict(lambda: collections.defaultdict(int))
+        # record date range in uploaded file
+        self.date_min = None
+        self.date_max = None
 
     def parse_record(self, record):
         try:
@@ -211,6 +214,9 @@ class UserSatisfactionUploadForm(forms.Form):
     def save(self):
         from performance.models import UserSatisfaction
 
+        self.date_min = list(self.records)[0]
+        self.date_max = self.date_min
+
         for date, record in self.records.items():
             UserSatisfaction.objects.update_or_create(
                 defaults={
@@ -219,3 +225,9 @@ class UserSatisfactionUploadForm(forms.Form):
                 },
                 date=date,
             )
+
+            # Keep track of records date range
+            if date < self.date_min:
+                self.date_min = date
+            if date > self.date_max:
+                self.date_max = date

--- a/mtp_api/apps/performance/tests/test_views.py
+++ b/mtp_api/apps/performance/tests/test_views.py
@@ -1,4 +1,5 @@
 import datetime
+from io import StringIO
 
 from django.urls import reverse
 from django.utils import timezone
@@ -6,7 +7,8 @@ from model_mommy import mommy
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from core.tests.utils import make_test_users
+from core.models import ScheduledCommand
+from core.tests.utils import create_super_admin, make_test_users
 from core.utils import monday_of_same_week
 from mtp_auth.tests.utils import AuthTestCaseMixin
 from performance.models import PerformanceData
@@ -166,3 +168,46 @@ class PerformanceDataViewTestCase(AuthTestCaseMixin, APITestCase):
 
         monday = monday_of_same_week(timezone.localdate())
         return monday - datetime.timedelta(weeks=weeks_ago)
+
+
+class UserSatisfactionUploadViewTestCase(AuthTestCaseMixin, APITestCase):
+    fixtures = ['initial_types.json', 'test_prisons.json', 'initial_groups.json']
+
+    def setUp(self):
+        super().setUp()
+        create_super_admin()
+
+        self.upload_url = reverse('admin:user_satisfaction_upload')
+
+    def test_triggers_update_performance_data(self):
+        test_data = [
+            # +------------+----------+------------------+
+            # | start date | end date | expected week_to |
+            # +------------+----------+------------------+
+            ('2021-01-01', '2021-01-31', '2021-02-01'),  # last week is complete (Sunday)
+            ('2021-07-01', '2021-07-31', '2021-07-31'),  # last week is incomplete
+        ]
+        for (start_date, end_date, expected_week_to) in test_data:
+            test_csv = self.fake_csv(start_date, end_date)
+
+            self.client.login(username='admin', password='adminadmin')
+            self.client.post(
+                self.upload_url,
+                data={'csv_file': test_csv},
+            )
+
+            # Check 'update_performance_data' is scheduled correctly
+            job = ScheduledCommand.objects.get(name='update_performance_data')
+            self.assertEqual(job.arg_string, f'--week-from={start_date} --week-to={expected_week_to}')
+            self.assertTrue(job.delete_after_next)
+            self.assertEqual(job.cron_entry, '*/10 * * * *')
+            job.delete()
+
+    def fake_csv(self, start_date, end_date):
+        test_csv = StringIO()
+        test_csv.write('creation date,type,feedback\n')
+        test_csv.write(f'{start_date} 00:00:00,aggregated-service-feedback,Rating of 5: 99\n')
+        test_csv.write(f'{end_date} 00:00:00,aggregated-service-feedback,Rating of 5: 99\n')
+        test_csv.seek(0)
+
+        return test_csv

--- a/mtp_api/apps/performance/tests/test_views.py
+++ b/mtp_api/apps/performance/tests/test_views.py
@@ -1,5 +1,6 @@
 import datetime
 from io import StringIO
+import pathlib
 
 from django.urls import reverse
 from django.utils import timezone
@@ -171,7 +172,6 @@ class PerformanceDataViewTestCase(AuthTestCaseMixin, APITestCase):
 
 
 class UserSatisfactionUploadViewTestCase(AuthTestCaseMixin, APITestCase):
-    fixtures = ['initial_types.json', 'test_prisons.json', 'initial_groups.json']
 
     def setUp(self):
         super().setUp()
@@ -211,3 +211,46 @@ class UserSatisfactionUploadViewTestCase(AuthTestCaseMixin, APITestCase):
         test_csv.seek(0)
 
         return test_csv
+
+
+class DigitalTakeupUploadViewTestCase(AuthTestCaseMixin, APITestCase):
+    fixtures = ['initial_types.json', 'test_nomis_mtp_prisons']
+
+    def setUp(self):
+        super().setUp()
+        create_super_admin()
+
+        self.upload_url = reverse('admin:digital_takeup_upload')
+        self.fixture_path = pathlib.Path(__file__).parent / 'files'
+        self.fixture_path = self.fixture_path / 'Money_to_Prisoner_Stats - 02.11.16.xls'
+
+        self.test_week = datetime.date(2016, 10, 31)  # Monday of week containing 2nd Nov 2016
+
+    def test_updates_performance_data_when_already_there(self):
+        PerformanceData.objects.create(week=self.test_week)
+
+        with self.fixture_path.open('rb') as f:
+            self.client.login(username='admin', password='adminadmin')
+            self.client.post(
+                self.upload_url,
+                data={'excel_file': f},
+            )
+
+        # Check 'update_performance_data' is scheduled correctly
+        job = ScheduledCommand.objects.get(name='update_performance_data')
+        week_to = self.test_week + datetime.timedelta(weeks=1)
+        self.assertEqual(job.arg_string, f'--week-from={self.test_week} --week-to={week_to}')
+        self.assertTrue(job.delete_after_next)
+        self.assertEqual(job.cron_entry, '*/10 * * * *')
+
+    def test_doesnt_update_performance_data_when_not_generated_yet(self):
+        with self.fixture_path.open('rb') as f:
+            self.client.login(username='admin', password='adminadmin')
+            self.client.post(
+                self.upload_url,
+                data={'excel_file': f},
+            )
+
+        job = ScheduledCommand.objects.filter(name='update_performance_data')
+
+        self.assertFalse(job.exists())


### PR DESCRIPTION
Background
=========
Performance Data is derived from User Satisfaction data and from Digital Take-up data (among other things).
These weekly records are created/updated every Monday for the week of 2 weeks ago, to allow for late data (these are updated via [`update_performance_data`](https://github.com/ministryofjustice/money-to-prisoners-api/blob/b439932e864d2d29e186736ec7345ba72e2dc928/mtp_api/apps/performance/management/commands/update_performance_data.py) management command).

This changeset generate/update the Performance Data for the relevant week(s) when User Satisfaction/Digital Take-up is uploaded.

User Satisfaction
============
We tend to upload this CSV file on a monthly basis for the month before. 
On upload the completed weeks are updated, e.g. if last date in CSV file is a Sunday that week including it will be updated, if not only the first n-1 weeks will be updated.
The assumption is that:
- these CSV files contain a continuous range of dates
- the first few dates would complete a previously updated week
- the last week may be complete (generate/update) or not (will be generated/updated on next upload)

Digital Take-up
===========
These xls files tend to be be uploaded more often. They include only the Digital Take-up for a single day.
The logic to determine whether or not to update the corresponding Performance data record is therefore different.

The idea here is that:
- if these xls files were uploaded in a timely manner (e.g. few days after) we don't need to generate/update the Performance data as the management command it will eventually run and use the data (Performance data record for that week not present yet)
- if these xls files are updated "late" there will be already a Performance data record for that corresponding week and that will need to be updated.



Ticket: https://dsdmoj.atlassian.net/browse/MTP-1899