### PR TITLE
Update dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,8 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=12.1.0
+money-to-prisoners-common~=12.2.0
 
-psycopg2-binary>=2.8.4,<2.9
+psycopg2-binary~=2.8.6
 djangorestframework>=3.9.1,<3.10.0
 drf-yasg==1.17.1
 django-model-utils==2.4
@@ -11,13 +11,10 @@ oauthlib>=2.1,<3
 django-oauth-toolkit==1.2.0
 drf-extensions==0.3.1
 drf-nested-routers==0.11.1
-Faker>=0.8,<0.9
-model-mommy>=1.5,<1.6
-crontab==0.21.3
+crontab~=0.23
 xlrd>=1.0.0,<2
 reportlab>=3.4,<4
 numpy>=1.18,<2
 scipy>=1.4,<2
 openpyxl>=2.6,<2.7
 boto3>=1.12,<2
-dictdiffer==0.8.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,14 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=12.1.0
+money-to-prisoners-common[testing]~=12.2.0
 
 -r base.txt
 
-parameterized==0.7.4
+dictdiffer~=0.9.0
+Faker~=8.10
+model-mommy~=2.0.0
+parameterized~=0.8.1
+
 pdbpp
 django-pdb
 django-pudb3


### PR DESCRIPTION
• mtp-common brings along many other library updates, none should have breaking changes
• move testing-only dependencies into appropriate requirements file
• update only the simplest non-testing libraries