### PR TITLE
Fix oauth-provider patch

### DIFF
--- a/mtp_api/apps/mtp_auth/patches.py
+++ b/mtp_api/apps/mtp_auth/patches.py
@@ -22,10 +22,9 @@ class ModifiedTokenView(TokenView):
         response = super().post(request, *args, **kwargs)
         if response.status_code == 400:
             response_content = json.loads(response.content)
-            if (
-                response_content.get('error') == 'invalid_grant' and
-                'Invalid credentials given' in response_content.get('error_description')
-            ):
+            error = response_content.get('error')
+            error_description = response_content.get('error_description') or ''
+            if error == 'invalid_grant' and 'Invalid credentials given' in error_description:
                 response.status_code = 401
         return response
 

--- a/mtp_api/apps/mtp_auth/tests/test_patches.py
+++ b/mtp_api/apps/mtp_auth/tests/test_patches.py
@@ -4,7 +4,7 @@ from unittest import mock
 from django.urls import reverse
 from mtp_common.test_utils import silence_logger
 from oauth2_provider.models import Application
-from oauthlib.oauth2 import InvalidRequestError, UnsupportedGrantTypeError
+from oauthlib.oauth2 import InvalidRequestError, InvalidGrantError, UnsupportedGrantTypeError
 
 from core.tests.utils import make_test_users
 from mtp_auth.constants import CASHBOOK_OAUTH_CLIENT_ID
@@ -47,6 +47,10 @@ class OauthTokenRequestPatchTestCase(AuthBaseTestCase):
         # pretends that request was malformed: status code should NOT be modified remaining 400
 
         mocked_token_request.side_effect = UnsupportedGrantTypeError()
+        response = self.try_login()
+        self.assertEqual(response.status_code, 400)
+
+        mocked_token_request.side_effect = InvalidGrantError()
         response = self.try_login()
         self.assertEqual(response.status_code, 400)
 


### PR DESCRIPTION
Invalid grant errors do not always have a description. An error with 'Invalid credentials given.' description should still be converted to 401 and others can still remain 400.