### PR TITLE
Relax prerequisite environment variable validation for uploading to Analytical Platform

### DIFF
--- a/mtp_api/apps/core/management/commands/upload_dump_for_ap.py
+++ b/mtp_api/apps/core/management/commands/upload_dump_for_ap.py
@@ -18,7 +18,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if not all([settings.ANALYTICAL_PLATFORM_BUCKET,
-                    settings.AWS_IAM_ROLE_ARN,
                     settings.ANALYTICAL_PLATFORM_BUCKET_PATH]):
             self.stderr.write(self.style.WARNING('Cannot upload dump to Analytical Platform'))
             return

--- a/mtp_api/apps/core/tests/test_upload_dump_for_ap.py
+++ b/mtp_api/apps/core/tests/test_upload_dump_for_ap.py
@@ -14,7 +14,6 @@ class TestUploadDumpForAp(TestCase):
 
     @mock.patch('core.management.commands.upload_dump_for_ap.upload_file_to_analytical_platform')
     @override_settings(ANALYTICAL_PLATFORM_BUCKET='')
-    @override_settings(AWS_IAM_ROLE_ARN='test')
     @override_settings(ANALYTICAL_PLATFORM_BUCKET_PATH='test')
     def test_validating_if_bucked_name_is_not_present(self, mock_upload_file_to_analytical_platform):
         call_command('upload_dump_for_ap', 'some_path', settings.ANALYTICAL_PLATFORM_BUCKET)
@@ -23,16 +22,6 @@ class TestUploadDumpForAp(TestCase):
 
     @mock.patch('core.management.commands.upload_dump_for_ap.upload_file_to_analytical_platform')
     @override_settings(ANALYTICAL_PLATFORM_BUCKET='test')
-    @override_settings(AWS_IAM_ROLE_ARN='')
-    @override_settings(ANALYTICAL_PLATFORM_BUCKET_PATH='test')
-    def test_validating_if_iam_arn_role_is_not_present(self, mock_upload_file_to_analytical_platform):
-        call_command('upload_dump_for_ap', 'some_path', 'bucket_name')
-
-        mock_upload_file_to_analytical_platform.assert_not_called()
-
-    @mock.patch('core.management.commands.upload_dump_for_ap.upload_file_to_analytical_platform')
-    @override_settings(ANALYTICAL_PLATFORM_BUCKET='test')
-    @override_settings(AWS_IAM_ROLE_ARN='test')
     @override_settings(ANALYTICAL_PLATFORM_BUCKET_PATH='')
     def test_validating_if_bucket_path_is_not_present(self, mock_upload_file_to_analytical_platform):
         call_command('upload_dump_for_ap', 'some_path', 'bucket_name')


### PR DESCRIPTION
… because new kubernetes cluster using IRSA will not require assuming an IAM role. The code to assume the role will remain until application is fully migrated.