### PR TITLE
MTP-1921: Improve Azure Application Insights request tracing and logging

### DIFF
--- a/api.ini
+++ b/api.ini
@@ -1,7 +1,7 @@
 [uwsgi]
 procname = uwsgi_%n
 die-on-term = 1
-lazy-apps = 0
+lazy-apps = 1
 vacuum = 1
 
 master = true

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -265,6 +265,13 @@ LOGGING = {
         },
     },
 }
+if APPLICATIONINSIGHTS_CONNECTION_STRING:
+    # Sends messages from `mtp` logger to Azure Application Insights
+    LOGGING['handlers']['azure'] = {
+        'level': 'INFO',
+        'class': 'mtp_common.application_insights.AppInsightsLogHandler',
+    }
+    LOGGING['loggers']['mtp']['handlers'].append('azure')
 
 TEST_RUNNER = 'mtp_common.test_utils.runner.TestRunner'
 

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -272,6 +272,7 @@ if APPLICATIONINSIGHTS_CONNECTION_STRING:
         'class': 'mtp_common.application_insights.AppInsightsLogHandler',
     }
     LOGGING['loggers']['mtp']['handlers'].append('azure')
+    LOGGING['root']['handlers'].append('azure')
 
 TEST_RUNNER = 'mtp_common.test_utils.runner.TestRunner'
 

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -105,22 +105,17 @@ MIDDLEWARE = (
     'django.middleware.security.SecurityMiddleware',
 )
 
-if os.environ.get('APPLICATIONINSIGHTS_CONNECTION_STRING'):
-    from opencensus.ext.azure.trace_exporter import AzureExporter
+APPLICATIONINSIGHTS_CONNECTION_STRING = os.environ.get('APPLICATIONINSIGHTS_CONNECTION_STRING')
+if APPLICATIONINSIGHTS_CONNECTION_STRING:
+    from mtp_common.application_insights import AppInsightsTraceExporter
+    from opencensus.trace.samplers import ProbabilitySampler
 
-    def callback_add_role_name(envelope):
-        """ Callback function for opencensus """
-        """ This configures cloud_RoleName """
-        envelope.tags['ai.cloud.role'] = 'mtp-api'
-        envelope.tags['ai.cloud.roleInstance'] = 'mtp-api'
-        return True
-    azure_exporter = AzureExporter(connection_string=os.environ.get('APPLICATIONINSIGHTS_CONNECTION_STRING'))
-    azure_exporter.add_telemetry_processor(callback_add_role_name)
+    # Sends traces to Azure Application Insights
     MIDDLEWARE += ('opencensus.ext.django.middleware.OpencensusMiddleware',)
     OPENCENSUS = {
         'TRACE': {
-            'SAMPLER': 'opencensus.trace.samplers.ProbabilitySampler(rate=1)',  # TODO: not 1 in prod
-            'EXPORTER': azure_exporter,
+            'SAMPLER': ProbabilitySampler(rate=0.1 if ENVIRONMENT == 'prod' else 1),
+            'EXPORTER': AppInsightsTraceExporter(),
         }
     }
 

--- a/mtp_api/tasks.py
+++ b/mtp_api/tasks.py
@@ -1,3 +1,5 @@
+import django
 from mtp_common.spooling import autodiscover_tasks
 
+django.setup()
 autodiscover_tasks()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=13.9.1
+money-to-prisoners-common~=13.10.0
 
 psycopg2-binary~=2.8.6
 djangorestframework~=3.13.0
@@ -17,8 +17,6 @@ reportlab>=3.6,<4
 numpy>=1.21,<2
 scipy>=1.7,<2
 openpyxl~=3.0
-opencensus-ext-azure~=1.1
-opencensus-ext-django~=0.7
 
 # these are used mainly in tests, but are required to load random data in test environments
 Faker~=13.14

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=13.9.1
+money-to-prisoners-common[testing]~=13.10.0
 
 -r base.txt
 


### PR DESCRIPTION
uWSGI now runs in lazy mode such that each process loads its own complete application rather than forking the master. This now requires the spooler to setup django.

Lazy apps are needed if telemetry is to be sent to Azure Application Insights: the `opencensus` library starts a background thread on launch to transport telemetry to Azure, but if uWSGI loads the application and _then_ forks, this thread is no longer accessible from the new process.

In `prod` environment:
• `mtp` logs of level INFO and higher
• other logs of level WARNING and higher
• 10% of requests traces
…will be sent.

Depends on [common#539](https://github.com/ministryofjustice/money-to-prisoners-common/pull/539).