### PR TITLE
Add management command to remove all monitors and saved searches for a given user

### DIFF
--- a/mtp_api/apps/credit/tests/test_private_estate.py
+++ b/mtp_api/apps/credit/tests/test_private_estate.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import Permission
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
-from model_mommy import mommy
+from model_bakery import baker
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -28,8 +28,8 @@ class PrivateEstateBatchTestCase(AuthTestCaseMixin, APITestCase):
     def setUp(self):
         super().setUp()
 
-        self.private_prison = mommy.make(Prison, name='Private', private_estate=True)
-        self.private_bank_account = mommy.make(PrisonBankAccount, prison=self.private_prison)
+        self.private_prison = baker.make(Prison, name='Private', private_estate=True)
+        self.private_bank_account = baker.make(PrisonBankAccount, prison=self.private_prison)
 
         test_users = make_test_users(clerks_per_prison=2)
         self.prison_clerks = test_users['prison_clerks']

--- a/mtp_api/apps/credit/tests/test_stuck_credits.py
+++ b/mtp_api/apps/credit/tests/test_stuck_credits.py
@@ -6,7 +6,7 @@ from django.core.cache import cache
 from django.core.management import CommandError, call_command
 from django.test import TestCase, override_settings
 from django.utils import timezone
-from model_mommy import mommy
+from model_bakery import baker
 from parameterized import parameterized
 import responses
 
@@ -68,7 +68,7 @@ class FixStuckCreditsTestCase(TestCase):
         nomis_transaction_already_linked.cache_clear()
 
     def mock_uncredited_credits(self):
-        credit: Credit = mommy.make(
+        credit: Credit = baker.make(
             Credit,
             prisoner_number=self.sample_prisoner_number,
             prisoner_name='JAMES HALLS',
@@ -77,7 +77,7 @@ class FixStuckCreditsTestCase(TestCase):
             received_at=timezone.make_aware(datetime.datetime(2021, 10, 10, 9)),
             resolution=CREDIT_RESOLUTION.PENDING,
         )
-        mommy.make(
+        baker.make(
             Payment,
             credit=credit,
             amount=credit.amount,

--- a/mtp_api/apps/disbursement/tests/utils.py
+++ b/mtp_api/apps/disbursement/tests/utils.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 from faker import Faker
-from model_mommy.recipe import Recipe, seq
+from model_bakery.recipe import Recipe, seq
 
 from core.tests.utils import MockModelTimestamps
 from credit.tests.utils import random_amount, build_sender_prisoner_pairs

--- a/mtp_api/apps/mtp_auth/tests/mommy_recipes.py
+++ b/mtp_api/apps/mtp_auth/tests/mommy_recipes.py
@@ -3,11 +3,11 @@ import string
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
+from django.utils import timezone
 from django.utils.text import slugify
 from faker import Faker
-from model_mommy import timezone
-from model_mommy.mommy import make
-from model_mommy.recipe import Recipe
+from model_bakery.baker import make
+from model_bakery.recipe import Recipe
 
 User = get_user_model()
 

--- a/mtp_api/apps/mtp_auth/tests/test_account_request_emails.py
+++ b/mtp_api/apps/mtp_auth/tests/test_account_request_emails.py
@@ -6,7 +6,7 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.utils.timezone import now, localtime
 from faker import Faker
-from model_mommy import mommy
+from model_bakery import baker
 
 from core.tests.utils import make_test_users, make_test_user_admins
 from mtp_auth.management.commands.send_account_request_emails import Command
@@ -25,7 +25,7 @@ class AccountRequestEmailTestCase(TestCase):
         make_test_user_admins()
 
     def _make_account_request(self, role, prison, created):
-        return mommy.make(
+        return baker.make(
             AccountRequest,
             role=role,
             prison=prison,

--- a/mtp_api/apps/mtp_auth/tests/test_login_counts.py
+++ b/mtp_api/apps/mtp_auth/tests/test_login_counts.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils.dateformat import format as date_format
 from django.utils.timezone import make_aware
-from model_mommy import mommy
+from model_bakery import baker
 from oauth2_provider.models import Application
 
 from mtp_auth.models import Login, PrisonUserMapping
@@ -31,14 +31,14 @@ class LoginCountTestCase(TestCase):
             client_type='confidential',
             authorization_grant_type='password',
             name='Test App',
-            user=mommy.make(User),
+            user=baker.make(User),
         )
-        prison = mommy.make(Prison, nomis_id='ABC')
-        user_in_prison = mommy.make(User)
-        another_user_in_prison = mommy.make(User)
-        mommy.make(PrisonUserMapping, user=user_in_prison, prisons=[prison])
-        mommy.make(PrisonUserMapping, user=another_user_in_prison, prisons=[prison])
-        user_not_in_prison = mommy.make(User)
+        prison = baker.make(Prison, nomis_id='ABC')
+        user_in_prison = baker.make(User)
+        another_user_in_prison = baker.make(User)
+        baker.make(PrisonUserMapping, user=user_in_prison, prisons=[prison])
+        baker.make(PrisonUserMapping, user=another_user_in_prison, prisons=[prison])
+        user_not_in_prison = baker.make(User)
 
         # last month: 3 login in prison
         self.login(user_in_prison, application, (2018, 3, 10))

--- a/mtp_api/apps/mtp_auth/tests/test_views.py
+++ b/mtp_api/apps/mtp_auth/tests/test_views.py
@@ -11,7 +11,7 @@ from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.models import Group
 from django.urls import reverse, reverse_lazy
 from django.utils.timezone import now
-from model_mommy import mommy
+from model_bakery import baker
 from mtp_common.test_utils import silence_logger
 from oauth2_provider.models import AccessToken, Application, RefreshToken
 from rest_framework import status
@@ -2465,7 +2465,7 @@ class AccountRequestTestCase(AuthBaseTestCase):
         admin = self.users['prison_clerk_uas'][0]
         role = Role.objects.get(name='prison-clerk')
         prison = admin.prisonusermapping.prisons.first()
-        request = mommy.make(AccountRequest, role=role, prison=prison)
+        request = baker.make(AccountRequest, role=role, prison=prison)
         url_detail = reverse('accountrequest-detail', kwargs={'pk': request.pk})
         response = self.client.get(
             url_detail,
@@ -2485,10 +2485,10 @@ class AccountRequestTestCase(AuthBaseTestCase):
         prison = admin.prisonusermapping.prisons.first()
         url_list = reverse('accountrequest-list')
 
-        visible_requests = mommy.make(AccountRequest, 3, role=role, prison=prison)
+        visible_requests = baker.make(AccountRequest, 3, role=role, prison=prison)
         invisible_requests = []
         for another_role in Role.objects.exclude(name='prison-clerk'):
-            invisible_requests.append(mommy.make(AccountRequest, role=another_role, prison=prison))
+            invisible_requests.append(baker.make(AccountRequest, role=another_role, prison=prison))
 
         response = self.client.get(
             url_list,
@@ -2530,7 +2530,7 @@ class AccountRequestTestCase(AuthBaseTestCase):
         Role.objects.get(name='bank-admin').assign_to_user(admin)
         url_list = reverse('accountrequest-list')
 
-        mommy.make(AccountRequest, 3, role=cashbook_role, prison=prison)
+        baker.make(AccountRequest, 3, role=cashbook_role, prison=prison)
         response = self.client.get(
             url_list,
             format='json',
@@ -2545,8 +2545,8 @@ class AccountRequestTestCase(AuthBaseTestCase):
         url_list = reverse('accountrequest-list')
 
         another_prison = Prison.objects.exclude(nomis_id=prison.nomis_id).first()
-        visible_requests = mommy.make(AccountRequest, 3, role=role, prison=prison)
-        invisible_requests = mommy.make(AccountRequest, 5, role=role, prison=another_prison)
+        visible_requests = baker.make(AccountRequest, 3, role=role, prison=prison)
+        invisible_requests = baker.make(AccountRequest, 5, role=role, prison=another_prison)
 
         response = self.client.get(
             url_list,
@@ -2617,7 +2617,7 @@ class AccountRequestTestCase(AuthBaseTestCase):
         user_count = User.objects.count()
 
         def assert_user_created(payload, user_admin):
-            request = mommy.make(AccountRequest, role=role, prison=prison)
+            request = baker.make(AccountRequest, role=role, prison=prison)
             url_detail = reverse('accountrequest-detail', kwargs={'pk': request.pk})
             response = self.client.patch(
                 url_detail,
@@ -2663,7 +2663,7 @@ class AccountRequestTestCase(AuthBaseTestCase):
         PrisonUserMapping.objects.assign_prisons_to_user(admin, Prison.objects.all())
         user_count = User.objects.count()
 
-        request = mommy.make(AccountRequest, role=role, prison=prison)
+        request = baker.make(AccountRequest, role=role, prison=prison)
         url_detail = reverse('accountrequest-detail', kwargs={'pk': request.pk})
         response = self.client.patch(
             url_detail,
@@ -2769,7 +2769,7 @@ class AccountRequestTestCase(AuthBaseTestCase):
             for group in scenario['previous_extra_groups']:
                 user.groups.add(Group.objects.get(name=group))
 
-            request = mommy.make(
+            request = baker.make(
                 AccountRequest,
                 first_name=user.first_name, last_name=user.last_name,
                 email=user.email, username=user.username,
@@ -2823,7 +2823,7 @@ class AccountRequestTestCase(AuthBaseTestCase):
 
         user = basic_user.make(is_active=random.random() > 0.2)
         Role.objects.get(name='security').assign_to_user(user)
-        request = mommy.make(
+        request = baker.make(
             AccountRequest,
             first_name=user.first_name, last_name=user.last_name,
             email=user.email, username=user.username,
@@ -2862,7 +2862,7 @@ class AccountRequestTestCase(AuthBaseTestCase):
         PrisonUserMapping.objects.create(user=user).prisons.set([prison])
 
         # request to move to cashbook in same prison, change email and make user admin
-        request = mommy.make(
+        request = baker.make(
             AccountRequest,
             first_name=user.first_name, last_name=user.last_name,
             username=user.username,
@@ -2897,7 +2897,7 @@ class AccountRequestTestCase(AuthBaseTestCase):
         previous_email = user.email
 
         # request to move to cashbook in same prison, change email and make user admin
-        request = mommy.make(
+        request = baker.make(
             AccountRequest,
             first_name=user.first_name, last_name=user.last_name,
             username=user.username,
@@ -2933,8 +2933,8 @@ class AccountRequestTestCase(AuthBaseTestCase):
         self.assertNotIn(another_role, Role.objects.get_roles_for_user(admin))
         another_prison = Prison.objects.exclude(nomis_id=prison.nomis_id).first()
         invisible_requests = [
-            mommy.make(AccountRequest, role=role, prison=another_prison),
-            mommy.make(AccountRequest, role=another_role, prison=prison),
+            baker.make(AccountRequest, role=role, prison=another_prison),
+            baker.make(AccountRequest, role=another_role, prison=prison),
         ]
         for request in invisible_requests:
             url_detail = reverse('accountrequest-detail', kwargs={'pk': request.pk})
@@ -2966,7 +2966,7 @@ class AccountRequestTestCase(AuthBaseTestCase):
 
         user = basic_user.make(is_active=True)
         role.assign_to_user(user)
-        mommy.make(
+        baker.make(
             AccountRequest,
             first_name=user.first_name, last_name=user.last_name,
             email=user.email, username=user.username,
@@ -3001,7 +3001,7 @@ class AccountRequestTestCase(AuthBaseTestCase):
 
         user = basic_user.make(is_active=True)
         role.assign_to_user(user)
-        mommy.make(
+        baker.make(
             AccountRequest,
             first_name=user.first_name, last_name=user.last_name,
             email=user.email, username=user.username,

--- a/mtp_api/apps/notification/tests/test_commands.py
+++ b/mtp_api/apps/notification/tests/test_commands.py
@@ -5,7 +5,7 @@ from unittest import mock
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 from django.utils import timezone
-from model_mommy import mommy
+from model_bakery import baker
 import openpyxl
 from openpyxl.utils import coordinate_to_tuple
 
@@ -146,7 +146,7 @@ class SendNotificationEmailsTestCase(NotificationBaseTestCase):
         sender_profile_1, sender_profile_2 = SenderProfile.objects.filter(debit_card_details__isnull=False)[:2]
         debit_card_1 = sender_profile_1.debit_card_details.first()
         debit_card_2 = sender_profile_2.debit_card_details.first()
-        credit = mommy.make(
+        credit = baker.make(
             Credit,
             received_at=period_start, amount=100,
             prisoner_number=prisoner_profile_1.prisoner_number, prisoner_name=prisoner_profile_1.prisoner_name,
@@ -156,14 +156,14 @@ class SendNotificationEmailsTestCase(NotificationBaseTestCase):
             is_counted_in_prisoner_profile_total=False,
             is_counted_in_sender_profile_total=False
         )
-        mommy.make(
+        baker.make(
             Payment,
             credit=credit,
             card_number_last_digits=debit_card_1.card_number_last_digits,
             card_expiry_date=debit_card_1.card_expiry_date,
             billing_address=debit_card_1.billing_addresses.first(),
         )
-        credit = mommy.make(
+        credit = baker.make(
             Credit,
             received_at=period_start, amount=200,
             prisoner_number=prisoner_profile_2.prisoner_number, prisoner_name=prisoner_profile_2.prisoner_name,
@@ -173,7 +173,7 @@ class SendNotificationEmailsTestCase(NotificationBaseTestCase):
             is_counted_in_prisoner_profile_total=False,
             is_counted_in_sender_profile_total=False
         )
-        mommy.make(
+        baker.make(
             Payment,
             credit=credit,
             card_number_last_digits=debit_card_2.card_number_last_digits,

--- a/mtp_api/apps/notification/tests/utils.py
+++ b/mtp_api/apps/notification/tests/utils.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.utils.crypto import get_random_string
 from faker import Faker
-from model_mommy import mommy
+from model_bakery import baker
 
 from credit.models import Credit, CREDIT_RESOLUTION
 from credit.tests.utils import random_amount
@@ -20,7 +20,7 @@ fake = Faker(locale='en_GB')
 
 def make_sender():
     sender = SenderProfile.objects.create()
-    mommy.make(
+    baker.make(
         DebitCardSenderDetails,
         sender=sender,
         card_number_last_digits=fake.credit_card_number()[-4:],
@@ -32,17 +32,17 @@ def make_sender():
 
 def make_recipient():
     recipient = RecipientProfile.objects.create()
-    bank_account = mommy.make(
+    bank_account = baker.make(
         BankAccount,
         sort_code=get_random_string(6, '1234567890'),
         account_number=get_random_string(8, '1234567890'),
     )
-    mommy.make(BankTransferRecipientDetails, recipient=recipient, recipient_bank_account=bank_account)
+    baker.make(BankTransferRecipientDetails, recipient=recipient, recipient_bank_account=bank_account)
     return recipient
 
 
 def make_prisoner():
-    return mommy.make(
+    return baker.make(
         PrisonerProfile,
         prisoner_name=random_prisoner_name(),
         prisoner_number=random_prisoner_number(),
@@ -55,7 +55,7 @@ def make_csfreq_credits(today, sender, count):
     debit_card = sender.debit_card_details.first()
     credit_list = []
     for day in range(count):
-        credit = mommy.make(
+        credit = baker.make(
             Credit,
             amount=random_amount(),
             sender_profile=sender,
@@ -63,7 +63,7 @@ def make_csfreq_credits(today, sender, count):
             resolution=CREDIT_RESOLUTION.CREDITED, reconciled=True, private_estate_batch=None,
         )
         if debit_card:
-            payment = mommy.make(
+            payment = baker.make(
                 Payment,
                 amount=credit.amount,
                 card_number_last_digits=debit_card.card_number_last_digits,
@@ -78,7 +78,7 @@ def make_csfreq_credits(today, sender, count):
 def make_drfreq_disbursements(today, recipient, count):
     disbursement_list = []
     for day in range(count):
-        disbursement = mommy.make(
+        disbursement = baker.make(
             Disbursement,
             amount=random_amount(),
             recipient_profile=recipient,
@@ -94,7 +94,7 @@ def make_csnum_credits(today, prisoner, count, sender_profile=None):
     for day in range(count):
         sender = sender_profile or make_sender()
         debit_card = sender.debit_card_details.first()
-        credit = mommy.make(
+        credit = baker.make(
             Credit,
             amount=random_amount(),
             sender_profile=sender,
@@ -103,7 +103,7 @@ def make_csnum_credits(today, prisoner, count, sender_profile=None):
             resolution=CREDIT_RESOLUTION.CREDITED, reconciled=True, private_estate_batch=None,
         )
         if debit_card:
-            payment = mommy.make(
+            payment = baker.make(
                 Payment,
                 amount=credit.amount,
                 card_number_last_digits=debit_card.card_number_last_digits,
@@ -119,7 +119,7 @@ def make_drnum_disbursements(today, prisoner, count, recipient_profile=None):
     disbursement_list = []
     for day in range(count):
         recipient = recipient_profile or make_recipient()
-        disbursement = mommy.make(
+        disbursement = baker.make(
             Disbursement,
             amount=random_amount(),
             recipient_profile=recipient,
@@ -136,7 +136,7 @@ def make_cpnum_credits(today, sender, count, prisoner_profile=None):
     credit_list = []
     for day in range(count):
         prisoner = prisoner_profile or make_prisoner()
-        credit = mommy.make(
+        credit = baker.make(
             Credit,
             amount=random_amount(),
             sender_profile=sender,
@@ -145,7 +145,7 @@ def make_cpnum_credits(today, sender, count, prisoner_profile=None):
             resolution=CREDIT_RESOLUTION.CREDITED, reconciled=True, private_estate_batch=None,
         )
         if debit_card:
-            payment = mommy.make(
+            payment = baker.make(
                 Payment,
                 amount=credit.amount,
                 card_number_last_digits=debit_card.card_number_last_digits,
@@ -161,7 +161,7 @@ def make_dpnum_disbursements(today, recipient, count, prisoner_profile=None):
     disbursement_list = []
     for day in range(count):
         prisoner = prisoner_profile or make_prisoner()
-        disbursement = mommy.make(
+        disbursement = baker.make(
             Disbursement,
             amount=random_amount(),
             recipient_profile=recipient,

--- a/mtp_api/apps/performance/tests/test_update_performance_data.py
+++ b/mtp_api/apps/performance/tests/test_update_performance_data.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from core.utils import monday_of_same_week
 from credit.constants import CREDIT_RESOLUTION
 from credit.models import Credit
-from model_mommy import mommy
+from model_bakery import baker
 from performance.models import DigitalTakeup, PerformanceData, UserSatisfaction
 from prison.models import Prison
 
@@ -35,14 +35,14 @@ class UpdatePerformanceDataTestTestCase(TestCase):
             day_with_time = datetime.datetime.combine(day, datetime.time.min)
             day_with_time = timezone.make_aware(day_with_time)
 
-            mommy.make(
+            baker.make(
                 Credit,
                 received_at=day_with_time,
                 resolution=CREDIT_RESOLUTION.CREDITED,
                 _quantity=credits_count,
             )
             # Also create a PENDING credit per day (to test ignored credits)
-            mommy.make(
+            baker.make(
                 Credit,
                 received_at=day_with_time,
                 resolution=CREDIT_RESOLUTION.PENDING,
@@ -69,8 +69,8 @@ class UpdatePerformanceDataTestTestCase(TestCase):
         self.assertEqual(record.credits_by_mtp, expected_credits_by_mtp)
 
     def test_update_digital_takeup(self):
-        prison_1 = mommy.make(Prison, name='Prison 1')
-        prison_2 = mommy.make(Prison, name='Prison 2')
+        prison_1 = baker.make(Prison, name='Prison 1')
+        prison_2 = baker.make(Prison, name='Prison 2')
 
         test_data = [
             # +-----+--------+----------------+-----------------+
@@ -92,7 +92,7 @@ class UpdatePerformanceDataTestTestCase(TestCase):
             (datetime.date(2021, 1, 3),   prison_2, 2345, 128),  # Sunday
         ]
         for day, prison, by_mtp, by_post in test_data:
-            mommy.make(
+            baker.make(
                 DigitalTakeup,
                 date=day,
                 prison=prison,
@@ -137,7 +137,7 @@ class UpdatePerformanceDataTestTestCase(TestCase):
             (datetime.date(2021, 2, 1), 92, 0.97, 95),    # Round up
         ]
         for (week, by_mtp, takeup, _) in test_data:
-            mommy.make(
+            baker.make(
                 PerformanceData,
                 week=week,
                 credits_by_mtp=by_mtp,

--- a/mtp_api/apps/performance/tests/test_views.py
+++ b/mtp_api/apps/performance/tests/test_views.py
@@ -4,7 +4,7 @@ import pathlib
 
 from django.urls import reverse
 from django.utils import timezone
-from model_mommy import mommy
+from model_bakery import baker
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -68,14 +68,14 @@ class PerformanceDataViewTestCase(AuthTestCaseMixin, APITestCase):
         )
 
     def test_percentages_are_formatted(self):
-        mommy.make(
+        baker.make(
             PerformanceData,
             week=self._monday_n_weeks_ago(4),
             digital_takeup=0.95,
             completion_rate=0.8111,
             user_satisfaction=0.96666666,
         )
-        mommy.make(
+        baker.make(
             PerformanceData,
             week=self._monday_n_weeks_ago(3),
             digital_takeup=0.0,
@@ -103,7 +103,7 @@ class PerformanceDataViewTestCase(AuthTestCaseMixin, APITestCase):
         records = []
         for age_weeks in [100, 50, 10]:
             records.append(
-                mommy.make(PerformanceData, week=self._monday_n_weeks_ago(age_weeks))
+                baker.make(PerformanceData, week=self._monday_n_weeks_ago(age_weeks))
             )
 
         # By default only last 52 weeks records are returned

--- a/mtp_api/apps/prison/tests/test_prisoner_balances.py
+++ b/mtp_api/apps/prison/tests/test_prisoner_balances.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import Permission
 from django.core.files.base import File
 from django.test import TestCase
 from django.urls import reverse_lazy
-from model_mommy import mommy
+from model_bakery import baker
 
 from prison.forms import PrisonerBalanceUploadForm
 from prison.models import Prison, PrisonerBalance, PrisonerLocation
@@ -225,7 +225,7 @@ class PrisonerBalanceUploadViewTestCase(PrisonerBalanceUploadBaseTestCase):
         different_prison = Prison.objects.exclude(pk=chosen_prison.pk).first()
         # put all prisoners in sample file into a different prison
         for prisoner_number in ('A1409AE', 'A1401AE'):
-            mommy.make(
+            baker.make(
                 PrisonerLocation,
                 prison=different_prison,
                 prisoner_number=prisoner_number,

--- a/mtp_api/apps/prison/tests/test_views.py
+++ b/mtp_api/apps/prison/tests/test_views.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateformat import format as format_date
-from model_mommy import mommy
+from model_bakery import baker
 from mtp_common.nomis import Connector
 from mtp_common.test_utils import silence_logger
 from parameterized import parameterized
@@ -120,9 +120,9 @@ class PrisonerLocationViewTestCase(AuthTestCaseMixin, APITestCase):
         repeated_p_num_1 = random_prisoner_number()
         repeated_p_num_2 = random_prisoner_number()
         # create two pre-existing PrisonerLocations so that we test the overwrite
-        mommy.make(PrisonerLocation, prisoner_number=repeated_p_num_1,
+        baker.make(PrisonerLocation, prisoner_number=repeated_p_num_1,
                    prison=self.prisons[0], active=True)
-        mommy.make(PrisonerLocation, prisoner_number=repeated_p_num_2,
+        baker.make(PrisonerLocation, prisoner_number=repeated_p_num_2,
                    prison=self.prisons[0], active=True)
         self.assertEqual(PrisonerLocation.objects.filter(active=True).count(), 2)
         self.assertEqual(PrisonerLocation.objects.filter(active=False).count(), 0)
@@ -277,7 +277,7 @@ class PrisonerLocationViewTestCase(AuthTestCaseMixin, APITestCase):
 
     def test_can_upload_when_none_inactive(self):
         # recent active locations exist, but do not matter
-        mommy.make(PrisonerLocation,
+        baker.make(PrisonerLocation,
                    prisoner_number=random_prisoner_number(), prison=self.prisons[0],
                    active=True,
                    created=timezone.now() - datetime.timedelta(minutes=1))
@@ -292,7 +292,7 @@ class PrisonerLocationViewTestCase(AuthTestCaseMixin, APITestCase):
 
     def test_can_upload_when_old_inactive(self):
         # inactive locations exist, but are not recent so do not matter
-        mommy.make(PrisonerLocation,
+        baker.make(PrisonerLocation,
                    prisoner_number=random_prisoner_number(), prison=self.prisons[0],
                    active=False,
                    created=timezone.now() - datetime.timedelta(minutes=17))
@@ -307,7 +307,7 @@ class PrisonerLocationViewTestCase(AuthTestCaseMixin, APITestCase):
 
     def test_cannot_upload_when_recent_inactive(self):
         # recent inactive locations exist, so cannot upload now
-        mommy.make(PrisonerLocation,
+        baker.make(PrisonerLocation,
                    prisoner_number=random_prisoner_number(), prison=self.prisons[0],
                    active=False,
                    created=timezone.now() - datetime.timedelta(minutes=1, seconds=4))
@@ -841,7 +841,7 @@ class PrisonViewTestCase(AuthTestCaseMixin, APITestCase):
 
     def test_exclude_empty_prisons(self):
         url = reverse('prison-list')
-        empty_prison = mommy.make(Prison, name='Empty')
+        empty_prison = baker.make(Prison, name='Empty')
         response = self.client.get(url + '?exclude_empty_prisons=True',
                                    HTTP_AUTHORIZATION=self.get_http_authorization_for_user(self.send_money_user),
                                    format='json')
@@ -915,7 +915,7 @@ class PrisonerCreditNoticeEmailViewTestCase(AuthTestCaseMixin, APITestCase):
 
         self.prisons = Prison.objects.all()
         for prison in self.prisons:
-            mommy.make(PrisonerCreditNoticeEmail, prison=prison)
+            baker.make(PrisonerCreditNoticeEmail, prison=prison)
 
     @property
     def list_url(self):

--- a/mtp_api/apps/security/management/commands/bulk_unmonitor.py
+++ b/mtp_api/apps/security/management/commands/bulk_unmonitor.py
@@ -1,0 +1,41 @@
+import textwrap
+
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand, CommandError
+
+from security.models import SavedSearch, PrisonerProfile, BankAccount, DebitCardSenderDetails
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """
+    Removes a user's monitored entities and deletes their saved searches
+    """
+    help = textwrap.dedent(__doc__).strip()
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument('username')
+        # TODO: add an option to move monitoring to a different user? requires deduplication
+
+    def handle(self, username, **options):
+        try:
+            user = User.objects.get_by_natural_key(username)
+        except User.DoesNotExist:
+            raise CommandError(f'User "{username}" not found')
+        self.stdout.write(f'Removing items monitored by {user.username} ({user.email})')
+
+        self.delete(SavedSearch, 'saved searches', user)
+        self.delete(PrisonerProfile.monitoring_users.through, 'monitored prisoners', user)
+        self.delete(BankAccount.monitoring_users.through, 'monitored bank account senders', user)
+        self.delete(DebitCardSenderDetails.monitoring_users.through, 'monitored debit card senders', user)
+
+    def delete(self, model, description, user):
+        self.stdout.write(f'Deleting all {description}…')
+        count, deleted_models = model.objects.filter(user=user).delete()
+        if count:
+            for model, count in deleted_models.items():
+                self.stdout.write(f'Deleted {count} × {model}')
+        else:
+            self.stdout.write(f'No {description} to delete')

--- a/mtp_api/apps/security/management/commands/update_security_profiles.py
+++ b/mtp_api/apps/security/management/commands/update_security_profiles.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.db.transaction import atomic
 from django.core.management import BaseCommand, CommandError
 
@@ -9,8 +7,6 @@ from disbursement.constants import DISBURSEMENT_RESOLUTION
 from disbursement.models import Disbursement
 from notification.tasks import create_notification_events
 from security.models import PrisonerProfile, SenderProfile, RecipientProfile
-
-logger = logging.getLogger('mtp')
 
 
 class Command(BaseCommand):

--- a/mtp_api/apps/security/tests/test_checks.py
+++ b/mtp_api/apps/security/tests/test_checks.py
@@ -8,7 +8,7 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
-from model_mommy import mommy
+from model_bakery import baker
 from rest_framework.test import APITestCase
 
 from core.tests.utils import make_test_users, FLAKY_TEST_WARNING
@@ -55,7 +55,7 @@ class CheckTestCase(APITestCase, AuthTestCaseMixin):
         mocked_now.return_value = timezone.make_aware(datetime.datetime(2019, 1, 1))
 
         user = basic_user.make()
-        check = mommy.make(
+        check = baker.make(
             Check,
             status=CHECK_STATUS.PENDING,
             actioned_at=None,
@@ -77,7 +77,7 @@ class CheckTestCase(APITestCase, AuthTestCaseMixin):
         mocked_now.return_value = timezone.make_aware(datetime.datetime(2019, 1, 1))
 
         user = basic_user.make()
-        check = mommy.make(
+        check = baker.make(
             Check,
             status=CHECK_STATUS.PENDING,
             actioned_at=None,
@@ -99,7 +99,7 @@ class CheckTestCase(APITestCase, AuthTestCaseMixin):
         mocked_now.return_value = timezone.make_aware(datetime.datetime(2019, 1, 1))
 
         existing_check_user, user = basic_user.make(_quantity=2)
-        check = mommy.make(
+        check = baker.make(
             Check,
             status=CHECK_STATUS.ACCEPTED,
             actioned_at=mocked_now() - datetime.timedelta(days=1),
@@ -121,7 +121,7 @@ class CheckTestCase(APITestCase, AuthTestCaseMixin):
         mocked_now.return_value = timezone.make_aware(datetime.datetime(2019, 1, 1))
 
         existing_check_user, user = basic_user.make(_quantity=2)
-        check = mommy.make(
+        check = baker.make(
             Check,
             status=CHECK_STATUS.REJECTED,
             actioned_at=mocked_now() - datetime.timedelta(days=1),
@@ -145,7 +145,7 @@ class CheckTestCase(APITestCase, AuthTestCaseMixin):
         mocked_now.return_value = timezone.make_aware(datetime.datetime(2019, 1, 1))
 
         user = basic_user.make()
-        check = mommy.make(
+        check = baker.make(
             Check,
             status=CHECK_STATUS.PENDING,
             actioned_at=None,
@@ -170,7 +170,7 @@ class CheckTestCase(APITestCase, AuthTestCaseMixin):
         mocked_now.return_value = timezone.make_aware(datetime.datetime(2019, 1, 1))
 
         existing_check_user, user = basic_user.make(_quantity=2)
-        check = mommy.make(
+        check = baker.make(
             Check,
             status=CHECK_STATUS.REJECTED,
             actioned_at=mocked_now() - datetime.timedelta(days=1),
@@ -194,7 +194,7 @@ class CheckTestCase(APITestCase, AuthTestCaseMixin):
         Test that rejecting a check without reason raises ValidationError.
         """
         users = make_test_users(clerks_per_prison=1)
-        check = mommy.make(
+        check = baker.make(
             Check,
             status=CHECK_STATUS.PENDING,
             actioned_at=None,
@@ -226,7 +226,7 @@ class CheckTestCase(APITestCase, AuthTestCaseMixin):
         mocked_now.return_value = timezone.make_aware(datetime.datetime(2019, 1, 1))
 
         existing_check_user, user = basic_user.make(_quantity=2)
-        check = mommy.make(
+        check = baker.make(
             Check,
             status=CHECK_STATUS.ACCEPTED,
             actioned_at=mocked_now() - datetime.timedelta(days=1),

--- a/mtp_api/apps/security/tests/test_commands.py
+++ b/mtp_api/apps/security/tests/test_commands.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.test.utils import captured_stdout
 from faker import Faker
-from model_mommy import mommy
+from model_bakery import baker
 
 from mtp_common.test_utils import silence_logger
 
@@ -420,27 +420,27 @@ class BulkUnmonitorCommandTestCase(TestCase):
     def test_bulk_unmonitor(self):
         fake = Faker(locale='en_GB')
         for user in self.security_staff:
-            mommy.make(
+            baker.make(
                 BankTransferSenderDetails,
-                sender=mommy.make(SenderProfile),
-                sender_bank_account=mommy.make(
+                sender=baker.make(SenderProfile),
+                sender_bank_account=baker.make(
                     BankAccount,
                     sort_code=get_random_string(6, '0123456789'),
                     account_number=get_random_string(8, '0123456789'),
                     monitoring_users=[user],
                 ),
             )
-            mommy.make(
+            baker.make(
                 DebitCardSenderDetails,
-                sender=mommy.make(SenderProfile),
+                sender=baker.make(SenderProfile),
                 card_number_last_digits=fake.credit_card_number()[-4:],
                 card_expiry_date=fake.credit_card_expire(),
                 postcode=fake.postcode(),
                 monitoring_users=[user],
             )
-            mommy.make(PrisonerProfile, monitoring_users=[user])
+            baker.make(PrisonerProfile, monitoring_users=[user])
             for _ in range(3):
-                mommy.make(SearchFilter, saved_search=mommy.make(SavedSearch, user=user))
+                baker.make(SearchFilter, saved_search=baker.make(SavedSearch, user=user))
 
         bank_account_count = BankAccount.objects.count()
         debit_card_sender_count = DebitCardSenderDetails.objects.count()

--- a/mtp_api/apps/security/tests/test_commands.py
+++ b/mtp_api/apps/security/tests/test_commands.py
@@ -33,23 +33,21 @@ class UpdateSecurityProfilesTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
-        test_users = make_test_users()
-        self.prison_clerks = test_users['prison_clerks']
-        self.security_staff = test_users['security_staff']
+        make_test_users()
         load_random_prisoner_locations()
 
     def _assert_counts(self):
         for sender_profile in SenderProfile.objects.all():
             self.assertEqual(
-                len(sender_profile.credits.filter(
+                sender_profile.credits.filter(
                     resolution=CREDIT_RESOLUTION.CREDITED
-                )),
+                ).count(),
                 sender_profile.credit_count
             )
             self.assertEqual(
-                sum([credit.amount for credit in sender_profile.credits.filter(
+                sum(credit.amount for credit in sender_profile.credits.filter(
                     resolution=CREDIT_RESOLUTION.CREDITED
-                )]),
+                )),
                 sender_profile.credit_total
             )
 
@@ -65,34 +63,34 @@ class UpdateSecurityProfilesTestCase(TestCase):
             bank_transfer_details__isnull=False
         ):
             self.assertEqual(
-                sum([disbursement.amount for disbursement in recipient_profile.disbursements.all()]),
+                sum(disbursement.amount for disbursement in recipient_profile.disbursements.all()),
                 recipient_profile.disbursement_total
             )
             self.assertEqual(
-                len(recipient_profile.disbursements.all()),
+                recipient_profile.disbursements.all().count(),
                 recipient_profile.disbursement_count
             )
 
         for prisoner_profile in PrisonerProfile.objects.all():
             self.assertEqual(
-                sum([credit.amount for credit in prisoner_profile.credits.filter(
+                sum(credit.amount for credit in prisoner_profile.credits.filter(
                     resolution=CREDIT_RESOLUTION.CREDITED
-                )]),
+                )),
                 prisoner_profile.credit_total
             )
             self.assertEqual(
-                len(prisoner_profile.credits.filter(
+                prisoner_profile.credits.filter(
                     resolution=CREDIT_RESOLUTION.CREDITED
-                )),
+                ).count(),
                 prisoner_profile.credit_count
             )
 
             self.assertEqual(
-                sum([disbursement.amount for disbursement in prisoner_profile.disbursements.all()]),
+                sum(disbursement.amount for disbursement in prisoner_profile.disbursements.all()),
                 prisoner_profile.disbursement_total
             )
             self.assertEqual(
-                len(prisoner_profile.disbursements.all()),
+                prisoner_profile.disbursements.all().count(),
                 prisoner_profile.disbursement_count
             )
         self.assertEqual(
@@ -340,37 +338,37 @@ class UpdateSecurityProfilesTestCase(TestCase):
 
         delete_non_related_nullable_fields(
             Payment.objects.all(),
-            null_fields_to_leave_populated=set([
+            null_fields_to_leave_populated={
                 'email',
                 'cardholder_name',
                 'card_number_first_digits',
                 'card_number_last_digits',
                 'card_expiry_date',
                 'billing_address',
-            ])
+            }
         )
         delete_non_related_nullable_fields(
             Transaction.objects.all(),
-            null_fields_to_leave_populated=set([
+            null_fields_to_leave_populated={
                 'sender_name',
                 'sender_sort_code',
                 'sender_account_number'
-            ])
+            }
         )
         delete_non_related_nullable_fields(
             Credit.objects.all(),
-            null_fields_to_leave_populated=set([
+            null_fields_to_leave_populated={
                 'prison',
                 'prisoner_name',
                 'prisoner_number',  # Needed to populate PrisonerProfile
-            ])
+            }
         )
         delete_non_related_nullable_fields(
             Disbursement.objects.all(),
-            null_fields_to_leave_populated=set([
+            null_fields_to_leave_populated={
                 'sort_code',  # Needed to populate BankAccount
                 'account_number'  # Needed to populate BankAccount
-            ])
+            }
         )
 
         call_command('update_security_profiles', verbosity=0)
@@ -383,9 +381,7 @@ class UpdateCurrentPrisonsTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
-        test_users = make_test_users()
-        self.prison_clerks = test_users['prison_clerks']
-        self.security_staff = test_users['security_staff']
+        make_test_users()
         load_random_prisoner_locations()
 
     @captured_stdout()

--- a/mtp_api/apps/security/tests/test_views/test_check_views.py
+++ b/mtp_api/apps/security/tests/test_views/test_check_views.py
@@ -5,7 +5,7 @@ from pprint import pformat
 import dictdiffer
 from django.urls import reverse
 from django.utils.timezone import make_aware, now
-from model_mommy import mommy
+from model_bakery import baker
 from parameterized import parameterized
 from rest_framework import status as http_status
 from rest_framework.test import APITestCase
@@ -48,7 +48,7 @@ class BaseCheckTestCase(APITestCase, AuthTestCaseMixin):
     def generate_checks(self):
         # create a pending check for each credit in initial state
         for credit in Credit.objects_all.filter(resolution=CREDIT_RESOLUTION.INITIAL):
-            mommy.make(
+            baker.make(
                 Check,
                 credit=credit,
                 status=CHECK_STATUS.PENDING,
@@ -57,7 +57,7 @@ class BaseCheckTestCase(APITestCase, AuthTestCaseMixin):
             )
 
         for credit in Credit.objects_all.filter(resolution=CREDIT_RESOLUTION.FAILED):
-            mommy.make(
+            baker.make(
                 Check,
                 credit=credit,
                 status=CHECK_STATUS.REJECTED,
@@ -70,7 +70,7 @@ class BaseCheckTestCase(APITestCase, AuthTestCaseMixin):
             )
 
         for credit in Credit.objects.all():
-            mommy.make(
+            baker.make(
                 Check,
                 credit=credit,
                 status=CHECK_STATUS.ACCEPTED,

--- a/mtp_api/apps/user_event_log/tests/test_utils.py
+++ b/mtp_api/apps/user_event_log/tests/test_utils.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils.timezone import make_aware
-from model_mommy import mommy
+from model_bakery import baker
 
 from user_event_log.constants import USER_EVENT_KINDS
 from user_event_log.utils import record_user_event
@@ -48,7 +48,7 @@ class RecordUserEventTestCase(TestCase):
             ),
         ]
 
-        user = mommy.make(User)
+        user = baker.make(User)
 
         request = Mock(user=user, path='test-path')
         for data, expected_data in scenarios:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,5 +19,5 @@ scipy>=1.7,<2
 openpyxl~=3.0
 
 # these are used mainly in tests, but are required to load random data in test environments
-Faker~=13.14
-model-mommy~=2.0.0
+Faker~=14.2
+model-bakery~=1.5


### PR DESCRIPTION
This is useful for when an FIU staff member leaves the group