### PR TITLE
Use source package for psycopg2 on macOS instead of pre-built binary

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,10 @@
 
 money-to-prisoners-common~=14.2.0
 
-psycopg2-binary~=2.8.6  # 2.9+ does not work with django 2.2
+# psycopg2 2.9+ does not work with django 2.2
+psycopg2~=2.8.6; sys_platform == 'darwin'
+psycopg2-binary~=2.8.6; sys_platform == 'linux'
+
 djangorestframework~=3.13.0
 drf-yasg~=1.20.0
 django-model-utils~=4.2.0


### PR DESCRIPTION
…because there is no ARM build for this old version