### PR TITLE
MTP-1956: Prevent Altcourse from receiving money on 30 May

### DIFF
--- a/mtp_api/apps/prison/tests/test_views.py
+++ b/mtp_api/apps/prison/tests/test_views.py
@@ -530,32 +530,6 @@ class PrisonerValidityViewTestCase(AuthTestCaseMixin, APITestCase):
             response = self.call_authorised_endpoint(data)
             self.assertEmptyResponse(response)
 
-    def test_valid_prisoner_found_with_correct_prison_filter(self):
-        valid_data = self.get_valid_data()
-        prisoner_location = PrisonerLocation.objects.get(prisoner_number=valid_data['prisoner_number'])
-        valid_data_with_filter = valid_data.copy()
-        valid_data_with_filter['prisons'] = prisoner_location.prison.nomis_id
-        response = self.call_authorised_endpoint(valid_data_with_filter)
-        self.assertValidResponse(response, valid_data)
-
-    def test_valid_prisoner_found_with_multiple_correct_prison_filter(self):
-        valid_data = self.get_valid_data()
-        valid_data_with_filter = valid_data.copy()
-        valid_data_with_filter['prisons'] = ','.join(Prison.objects.values_list('nomis_id', flat=True))
-        response = self.call_authorised_endpoint(valid_data_with_filter)
-        self.assertValidResponse(response, valid_data)
-
-    def test_valid_prisoner_not_found_with_incorrect_prison_filter(self):
-        valid_data = self.get_valid_data()
-        prisoner_location = PrisonerLocation.objects.get(prisoner_number=valid_data['prisoner_number'])
-        other_prisons = Prison.objects.exclude(nomis_id=prisoner_location.prison.nomis_id)
-        if other_prisons.count() == 0:
-            self.fail('Cannot test prisoner validity filtering as there are insufficient prisons')
-        valid_data_with_filter = valid_data.copy()
-        valid_data_with_filter['prisons'] = ','.join(other_prisons.values_list('nomis_id', flat=True))
-        response = self.call_authorised_endpoint(valid_data_with_filter)
-        self.assertEmptyResponse(response)
-
 
 class PrisonerAccountBalanceTestCase(AuthTestCaseMixin, APITestCase):
     fixtures = ['initial_types.json', 'test_prisons.json', 'initial_groups.json']

--- a/mtp_api/apps/prison/views.py
+++ b/mtp_api/apps/prison/views.py
@@ -141,14 +141,18 @@ class PrisonerValidityView(mixins.ListModelMixin, viewsets.GenericViewSet):
 
     def filter_queryset(self, queryset):
         queryset = super().filter_queryset(queryset)
-        filters = {
-            'prisoner_number': self.request.GET['prisoner_number'],
-            'prisoner_dob': self.request.GET['prisoner_dob'],
-        }
-        prisons = set(filter(None, self.request.GET.get('prisons', '').split(',')))
-        if prisons:
-            filters['prison__nomis_id__in'] = prisons
-        return queryset.filter(**filters)
+        queryset = queryset.filter(
+            prisoner_number=self.request.GET['prisoner_number'],
+            prisoner_dob=self.request.GET['prisoner_dob'],
+        )
+
+        # HMP Altcourse will temporarily not accept money
+        no_altcourse_start = datetime.datetime(2023, 5, 29, 23, tzinfo=timezone.utc)
+        no_altcourse_end = datetime.datetime(2023, 6, 1, 1, tzinfo=timezone.utc)
+        if no_altcourse_start <= timezone.now() <= no_altcourse_end:
+            queryset = queryset.exclude(prison__nomis_id='ACI')
+
+        return queryset
 
     def list(self, request, *args, **kwargs):
         prisoner_number = self.request.GET.get('prisoner_number', '')

--- a/mtp_api/apps/prison/views.py
+++ b/mtp_api/apps/prison/views.py
@@ -148,7 +148,7 @@ class PrisonerValidityView(mixins.ListModelMixin, viewsets.GenericViewSet):
 
         # HMP Altcourse will temporarily not accept money
         no_altcourse_start = datetime.datetime(2023, 5, 29, 23, tzinfo=timezone.utc)
-        no_altcourse_end = datetime.datetime(2023, 6, 1, 1, tzinfo=timezone.utc)
+        no_altcourse_end = datetime.datetime(2023, 5, 31, 1, tzinfo=timezone.utc)
         if no_altcourse_start <= timezone.now() <= no_altcourse_end:
             queryset = queryset.exclude(prison__nomis_id='ACI')
 


### PR DESCRIPTION
For 1 day, HMP Altcourse will not be accepting money. The precise timing is chosen based on [Worldpay cutoffs, i.e. midnight UTC](https://github.com/ministryofjustice/money-to-prisoners-bank-admin/blob/a4dd722fc5d0b83b25ddda683798d8e331391a45/mtp_bank_admin/apps/bank_admin/utils.py#L32C5-L40) with an hour either side just in case.