### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Backend and internal admin site for [Prisoner Money suite of apps](https://githu
 
 ## Requirements
 
-- Unix-like platform with Python 3.10 and NodeJS 18 (e.g. via [nvm](https://github.com/nvm-sh/nvm#installing-and-updating) or [fnm](https://github.com/Schniz/fnm#installation))
+- Unix-like platform with Python 3.10 and NodeJS 20 (e.g. via [nvm](https://github.com/nvm-sh/nvm#installing-and-updating) or [fnm](https://github.com/Schniz/fnm#installation))
 - PostgreSQL 14 (though the version is not a strict requirement as no special features are used)
 
 ## Developing

--- a/mtp_api/apps/account/views.py
+++ b/mtp_api/apps/account/views.py
@@ -19,7 +19,7 @@ class BalanceView(
 ):
     queryset = Balance.objects.all().order_by('-date')
     filter_backends = (DjangoFilterBackend,)
-    filter_class = BalanceListFilter
+    filterset_class = BalanceListFilter
     serializer_class = BalanceSerializer
 
     permission_classes = (IsAuthenticated, ActionsBasedPermissions)

--- a/mtp_api/apps/core/filters.py
+++ b/mtp_api/apps/core/filters.py
@@ -31,7 +31,6 @@ class ParamsOnlyFilterSetForm(forms.Form):
 
 
 class BaseFilterSet(django_filters.FilterSet):
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._meta.form = ParamsOnlyFilterSetForm

--- a/mtp_api/apps/core/filters.py
+++ b/mtp_api/apps/core/filters.py
@@ -245,10 +245,10 @@ class LogNomsOpsSearchDjangoFilterBackend(DjangoFilterBackend):
         """
         Same as the parent `filter_queryset` but it also logs some calls.
         """
-        filter_class = self.get_filter_class(view, queryset)
+        filterset_class = self.get_filterset_class(view, queryset)
 
-        if filter_class:
-            filterset = filter_class(request.query_params, queryset=queryset, request=request)
+        if filterset_class:
+            filterset = filterset_class(request.query_params, queryset=queryset, request=request)
             qs = filterset.qs
             if filterset.errors:
                 # Previous functionality was to return 0 rows on error, we replicate this here

--- a/mtp_api/apps/core/tests/test_filters.py
+++ b/mtp_api/apps/core/tests/test_filters.py
@@ -177,7 +177,7 @@ class UserTestView(
     View for the User model to be used in the LogNomsOpsSearchDjangoFilterBackendTestCase tests
     """
     queryset = User.objects.all()
-    filter_class = UserTestFilter
+    filterset_class = UserTestFilter
     filter_backends = (LogNomsOpsSearchDjangoFilterBackend, )
     permission_classes = (IsAuthenticated, )
 

--- a/mtp_api/apps/credit/views.py
+++ b/mtp_api/apps/credit/views.py
@@ -269,7 +269,7 @@ class CreditViewMixin:
 
 class GetCredits(CreditViewMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
     filter_backends = (LogNomsOpsSearchDjangoFilterBackend, SafeOrderingFilter)
-    filter_class = CreditListFilter
+    filterset_class = CreditListFilter
     ordering_fields = ('created', 'received_at', 'amount',
                        'prisoner_number', 'prisoner_name')
     action = 'list'
@@ -314,7 +314,7 @@ class CreditsGroupedByCreditedList(CreditViewMixin, generics.ListAPIView):
         CreditPermissions
     )
     filter_backends = (DjangoFilterBackend,)
-    filter_class = CreditListFilter
+    filterset_class = CreditListFilter
     action = 'list'
 
     def get_queryset(self):
@@ -509,7 +509,7 @@ class PrivateEstateBatchView(
     queryset = PrivateEstateBatch.objects.all()
     serializer_class = PrivateEstateBatchSerializer
     filter_backends = (DjangoFilterBackend,)
-    filter_class = PrivateEstateBatchFilter
+    filterset_class = PrivateEstateBatchFilter
 
     permission_classes = (
         IsAuthenticated, PrivateEstateBatchPermissions, BankAdminClientIDPermissions,

--- a/mtp_api/apps/disbursement/serializers.py
+++ b/mtp_api/apps/disbursement/serializers.py
@@ -29,13 +29,13 @@ class PrisonerInPrisonValidator:
 
 
 class PrisonPermittedValidator:
-    def set_context(self, serializer):
-        self.user = serializer.context['request'].user
+    requires_context = True
 
-    def __call__(self, value):
+    def __call__(self, value, serializer_field):
+        user = serializer_field.context['request'].user
         if (
             value not in
-            PrisonUserMapping.objects.get_prison_set_for_user(self.user)
+            PrisonUserMapping.objects.get_prison_set_for_user(user)
         ):
             raise serializers.ValidationError(
                 _('Cannot create a disbursement for this prison')

--- a/mtp_api/apps/disbursement/views.py
+++ b/mtp_api/apps/disbursement/views.py
@@ -124,7 +124,7 @@ class GetDisbursementsView(
 ):
     queryset = Disbursement.objects.all().order_by('-id')
     serializer_class = DisbursementSerializer
-    filter_class = DisbursementFilter
+    filterset_class = DisbursementFilter
     filter_backends = (LogNomsOpsSearchDjangoFilterBackend, SafeOrderingFilter)
     ordering_fields = ('created', 'amount', 'resolution', 'method', 'recipient_name',
                        'prisoner_number', 'prisoner_name')

--- a/mtp_api/apps/mtp_auth/tests/test_patches.py
+++ b/mtp_api/apps/mtp_auth/tests/test_patches.py
@@ -27,7 +27,7 @@ class OauthTokenRequestPatchTestCase(AuthBaseTestCase):
                     'username': self.user.username,
                     'password': self.user.username,
                     'client_id': self.cashbook_client.client_id,
-                    'client_secret': self.cashbook_client.client_secret,
+                    'client_secret': self.cashbook_client.client_id,  # NB: client_secret is hashed
                 }
             )
 

--- a/mtp_api/apps/mtp_auth/tests/test_views.py
+++ b/mtp_api/apps/mtp_auth/tests/test_views.py
@@ -159,7 +159,7 @@ class OauthTokenTestCase(AuthBaseTestCase):
                         'username': username,
                         'password': password,
                         'client_id': client.client_id,
-                        'client_secret': client.client_secret,
+                        'client_secret': client.client_id,  # NB: client_secret is hashed
                     }
                 )
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -185,7 +185,7 @@ class OauthTokenTestCase(AuthBaseTestCase):
                             'username': username,
                             'password': 'incorrect-password',
                             'client_id': client.client_id,
-                            'client_secret': client.client_secret,
+                            'client_secret': client.client_id,  # NB: client_secret is hashed
                         }
                     )
                 self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
@@ -1784,7 +1784,7 @@ class AccountLockoutTestCase(AuthBaseTestCase):
                 'username': user.username,
                 'password': user.username,
                 'client_id': client.client_id,
-                'client_secret': client.client_secret,
+                'client_secret': client.client_id,  # NB: client_secret is hashed
             }
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -1798,7 +1798,7 @@ class AccountLockoutTestCase(AuthBaseTestCase):
                     'username': user.username,
                     'password': 'incorrect-password',
                     'client_id': client.client_id,
-                    'client_secret': client.client_secret,
+                    'client_secret': client.client_id,  # NB: client_secret is hashed
                 }
             )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/mtp_api/apps/mtp_auth/urls_oauth2.py
+++ b/mtp_api/apps/mtp_auth/urls_oauth2.py
@@ -1,0 +1,8 @@
+from mtp_auth.patches import patch_oauth2_provider_token_view
+
+patch_oauth2_provider_token_view()
+
+from oauth2_provider import urls as oauth2_provider_urls  # noqa: E402
+
+
+urlpatterns = oauth2_provider_urls.base_urlpatterns

--- a/mtp_api/apps/mtp_auth/views.py
+++ b/mtp_api/apps/mtp_auth/views.py
@@ -117,7 +117,7 @@ class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.none()
     permission_classes = (IsAuthenticated, UserPermissions)
     filter_backends = (DjangoFilterBackend, filters.OrderingFilter,)
-    filter_class = UserFilterset
+    filterset_class = UserFilterset
     serializer_class = UserSerializer
 
     def get_queryset(self):
@@ -386,7 +386,7 @@ class AccountRequestFilterset(BaseFilterSet):
 
 class AccountRequestViewSet(viewsets.ModelViewSet):
     queryset = AccountRequest.objects.all()
-    filter_class = AccountRequestFilterset
+    filterset_class = AccountRequestFilterset
     filter_backends = (DjangoFilterBackend,)
     permission_classes = (AccountRequestPermissions,)
     serializer_class = AccountRequestSerializer

--- a/mtp_api/apps/notification/views.py
+++ b/mtp_api/apps/notification/views.py
@@ -68,7 +68,7 @@ class EventView(mixins.ListModelMixin, viewsets.GenericViewSet):
     )
     serializer_class = EventSerializer
     filter_backends = (DjangoFilterBackend, SafeOrderingFilter,)
-    filter_class = EventViewFilter
+    filterset_class = EventViewFilter
 
     permission_classes = (IsAuthenticated, ActionsBasedPermissions, NomsOpsClientIDPermissions)
 

--- a/mtp_api/apps/payment/views.py
+++ b/mtp_api/apps/payment/views.py
@@ -32,7 +32,7 @@ class BatchView(
     queryset = Batch.objects.all()
     serializer_class = BatchSerializer
     filter_backends = (DjangoFilterBackend,)
-    filter_class = BatchListFilter
+    filterset_class = BatchListFilter
 
     permission_classes = (
         IsAuthenticated, BatchPermissions, BankAdminClientIDPermissions
@@ -56,7 +56,7 @@ class PaymentView(
     queryset = Payment.objects.all()
     serializer_class = PaymentSerializer
     filter_backends = (DjangoFilterBackend,)
-    filter_class = PaymentListFilter
+    filterset_class = PaymentListFilter
 
     permission_classes = (
         IsAuthenticated, PaymentPermissions, SendMoneyClientIDPermissions

--- a/mtp_api/apps/performance/views.py
+++ b/mtp_api/apps/performance/views.py
@@ -526,7 +526,7 @@ class PerformanceDataView(ListAPIView):
     queryset = PerformanceData.objects.all()
     serializer_class = PerformanceDataSerializer
     filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
-    filter_class = PerformanceDataFilter
+    filterset_class = PerformanceDataFilter
     pagination_class = None
 
     permission_classes = (

--- a/mtp_api/apps/security/serializers.py
+++ b/mtp_api/apps/security/serializers.py
@@ -280,7 +280,7 @@ class CheckAutoAcceptRuleSerializer(serializers.ModelSerializer):
         write_only=True
     )
 
-    def is_valid(self, raise_exception=False):
+    def is_valid(self, *, raise_exception=False):
         # We override is_valid to make this check before the built-in validators catch it, so we can add our own
         # error message as we want to match against it in logic within noms-ops, therefore want it to be in our control
         if self.instance is None and CheckAutoAcceptRule.objects.filter(
@@ -294,7 +294,7 @@ class CheckAutoAcceptRuleSerializer(serializers.ModelSerializer):
                     'An existing AutoAcceptRule is present for this DebitCardSenderDetails/PrisonerProfile pair'
                 ]
             })
-        return super().is_valid(raise_exception)
+        return super().is_valid(raise_exception=raise_exception)
 
     def validate(self, attrs):
         if len(attrs['states']) != 1:

--- a/mtp_api/apps/security/serializers.py
+++ b/mtp_api/apps/security/serializers.py
@@ -435,7 +435,7 @@ class AcceptCheckSerializer(CheckCreditSerializer):
             'id',
             'credit',
             'description',
-            'rules'
+            'rules',
         )
 
     def validate(self, data):

--- a/mtp_api/apps/security/views.py
+++ b/mtp_api/apps/security/views.py
@@ -178,7 +178,7 @@ class SenderProfileView(
         'bank_transfer_details', 'debit_card_details',
     )
     filter_backends = (LogNomsOpsSearchDjangoFilterBackend, filters.OrderingFilter,)
-    filter_class = SenderProfileListFilter
+    filterset_class = SenderProfileListFilter
     serializer_class = SenderProfileSerializer
     ordering_param = api_settings.ORDERING_PARAM
     ordering_fields = (
@@ -295,7 +295,7 @@ class PrisonerProfileView(
         'prisons', 'provided_names'
     )
     filter_backends = (LogNomsOpsSearchDjangoFilterBackend, filters.OrderingFilter,)
-    filter_class = PrisonerProfileListFilter
+    filterset_class = PrisonerProfileListFilter
     serializer_class = PrisonerProfileSerializer
     ordering_fields = (
         'sender_count',
@@ -421,7 +421,7 @@ class RecipientProfileView(
         'bank_transfer_details'
     )
     filter_backends = (DjangoFilterBackend, filters.OrderingFilter)
-    filter_class = RecipientProfileListFilter
+    filterset_class = RecipientProfileListFilter
     serializer_class = RecipientProfileSerializer
     ordering_param = api_settings.ORDERING_PARAM
     ordering_fields = (
@@ -543,7 +543,7 @@ class CheckView(
 ):
     queryset = Check.objects.all()
     filter_backends = (DjangoFilterBackend, filters.OrderingFilter)
-    filter_class = CheckListFilter
+    filterset_class = CheckListFilter
     serializer_class = CheckCreditSerializer
     ordering_fields = ('created',)
     ordering = ('created',)
@@ -643,7 +643,7 @@ class CheckAutoAcceptRuleView(
 ):
     queryset = CheckAutoAcceptRule.objects.all()
     filter_backends = (DjangoFilterBackend,)
-    filter_class = CheckAutoAcceptRuleFilter
+    filterset_class = CheckAutoAcceptRuleFilter
     serializer_class = CheckAutoAcceptRuleSerializer
     ordering_fields = (
         'states_created', '-states_created',

--- a/mtp_api/apps/transaction/views.py
+++ b/mtp_api/apps/transaction/views.py
@@ -59,7 +59,7 @@ class TransactionView(
     mixins.CreateModelMixin, mixins.UpdateModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet
 ):
     filter_backends = (DjangoFilterBackendEmptyOnErrors, SafeOrderingFilter)
-    filter_class = TransactionListFilter
+    filterset_class = TransactionListFilter
     ordering_fields = ('received_at',)
     permission_classes = (
         IsAuthenticated, BankAdminClientIDPermissions,

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -232,7 +232,7 @@ LOGGING = {
             'datefmt': '%Y-%m-%dT%H:%M:%S',
         },
         'elk': {
-            '()': 'mtp_common.logging.ELKFormatter'
+            '()': 'mtp_common.logging.ELKFormatter',
         },
     },
     'handlers': {
@@ -288,7 +288,7 @@ if os.environ.get('SENTRY_DSN'):
         environment=ENVIRONMENT,
         release=APP_GIT_COMMIT or 'unknown',
         send_default_pii=DEBUG,
-        request_bodies='medium' if DEBUG else 'never',
+        max_request_body_size='medium' if DEBUG else 'never',
     )
 
 REST_FRAMEWORK = {
@@ -302,7 +302,7 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.JSONRenderer',
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'PAGE_SIZE': 20
+    'PAGE_SIZE': 20,
 }
 REQUEST_PAGE_DAYS = 5
 
@@ -314,12 +314,14 @@ LOGIN_URL = '/admin/login/'
 LOGIN_REDIRECT_URL = '/admin/'
 
 OAUTH2_PROVIDER = {
+    'PKCE_REQUIRED': False,
+    'OIDC_ENABLED': False,
     'ACCESS_TOKEN_EXPIRE_SECONDS': SESSION_COOKIE_AGE,
     'SCOPES': {
         'read': 'Read scope',
         'write': 'Write scope',
     },
-    'OAUTH2_VALIDATOR_CLASS': 'mtp_auth.validators.ApplicationRequestValidator'
+    'OAUTH2_VALIDATOR_CLASS': 'mtp_auth.validators.ApplicationRequestValidator',
 }
 OAUTH2_PROVIDER_APPLICATION_MODEL = 'oauth2_provider.Application'
 MTP_AUTH_LOCKOUT_COUNT = 5  # 5 times
@@ -370,19 +372,19 @@ SWAGGER_SETTINGS = {
             'scopes': {
                 'read': 'Read scope',
                 'write': 'Write scope',
-            }
-        }
+            },
+        },
     },
     'SHOW_REQUEST_HEADERS': True,
     'SECURITY': [{
-        'password': ['read', 'write']
+        'password': ['read', 'write'],
     }],
     'REFETCH_SCHEMA_WITH_AUTH': True,
     'OAUTH2_CONFIG': {
         'clientId': os.environ.get('MTP_SWAGGER_CLIENT_ID'),
         'clientSecret': os.environ.get('MTP_SWAGGER_CLIENT_SECRET'),
-        'appName': 'Money To Prisoners'
-    }
+        'appName': 'Money To Prisoners',
+    },
 }
 
 try:

--- a/mtp_api/settings/base.py
+++ b/mtp_api/settings/base.py
@@ -310,6 +310,9 @@ REQUEST_PAGE_DAYS = 5
 SESSION_COOKIE_AGE = 60 * 60  # 1 hour
 SESSION_SAVE_EVERY_REQUEST = True
 
+LOGIN_URL = '/admin/login/'
+LOGIN_REDIRECT_URL = '/admin/'
+
 OAUTH2_PROVIDER = {
     'ACCESS_TOKEN_EXPIRE_SECONDS': SESSION_COOKIE_AGE,
     'SCOPES': {
@@ -386,7 +389,3 @@ try:
     from .local import *  # noqa
 except ImportError:
     pass
-
-
-# TODO: remove after upgrade to django 3.2
-DEFAULT_HASHING_ALGORITHM = 'sha1'

--- a/mtp_api/urls.py
+++ b/mtp_api/urls.py
@@ -7,11 +7,7 @@ from django.views.generic import RedirectView
 from moj_irat.views import HealthcheckView, PingJsonView
 from mtp_common.metrics.views import metrics_view
 
-from mtp_auth.patches import patch_oauth2_provider_token_view
 from .views import schema_view
-
-patch_oauth2_provider_token_view()
-
 
 urlpatterns = [
     url(r'^', include('prison.urls')),
@@ -27,9 +23,11 @@ urlpatterns = [
     url(r'^', include('notification.urls')),
     url(r'^', include('performance.urls')),
 
-    url(r'^oauth2/', include(('oauth2_provider.urls', 'oauth2_provider'), namespace='oauth2_provider')),
+    url(r'^oauth2/', include(('mtp_auth.urls_oauth2', 'oauth2_provider'), namespace='oauth2_provider')),
+
     url(r'^admin/', admin.site.urls),
     url(r'^admin/', include('django.conf.urls.i18n')),
+
     url(r'^ping.json$', PingJsonView.as_view(
         build_date_key='APP_BUILD_DATE',
         commit_id_key='APP_GIT_COMMIT',
@@ -56,7 +54,8 @@ urlpatterns = [
 
     url(r'^$', lambda request: HttpResponse(content_type='text/plain', status=204)),
 ]
-if settings.ENVIRONMENT in ('test', 'local'):
+
+if settings.ENVIRONMENT != 'prod':
     urlpatterns.extend([
         url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
         url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,22 +4,23 @@ money-to-prisoners-common~=16.3.0
 
 psycopg2~=2.9.6
 
-djangorestframework~=3.13.0
-drf-yasg~=1.20.0
-django-model-utils~=4.2.0
-django-filter~=21.1.0
-oauthlib~=3.1.1
-django-oauth-toolkit~=1.5.0
+coreapi~=2.3.3
+djangorestframework~=3.14.0
+drf-yasg~=1.21.7
+django-model-utils~=4.3.1
+django-filter~=23.3
+oauthlib~=3.2.2
+django-oauth-toolkit~=2.3.0
 drf-extensions~=0.7.1
 drf-nested-routers~=0.93.4
 crontab~=1.0
 xlrd~=2.0.1
-reportlab>=3.6,<4
-numpy>=1.21,<2
-scipy>=1.7,<2
-openpyxl~=3.0
-pyjwt~=2.3.0
+reportlab>=4.0,<4.1
+numpy>=1.26,<2
+scipy>=1.11,<2
+openpyxl~=3.1
+pyjwt~=2.8.0
 
 # these are used mainly in tests, but are required to load random data in test environments
-Faker~=17.4
-model-bakery~=1.5
+Faker~=19.13
+model-bakery~=1.17

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=16.2.0
+money-to-prisoners-common~=16.3.0
 
 psycopg2~=2.9.6
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=16.2.0
+money-to-prisoners-common[testing]~=16.3.0
 
 -r base.txt
 


### PR DESCRIPTION
…which (where relevant) claim to still support Django 3.2.

• `django-filter` has renamed the `filter_class` attribute on views to `filterset_class`
• `django-oauth-toolkit` (and maybe `oauthlib`) have various changes but for sure the `client_secret` is now stored in hashed form so cannot be recalled from db in tests
• `django-rest-framework` no longer provides context _prior_ to calling validators (now optionally provided in regular validation call) and `Serializer.is_valid()` takes keyword-only arguments
• `sentry-sdk` has changed config attribute `request_bodies` to `max_request_body_size` (some time ago??)