### PR TITLE
MTP-1976: Ensure that monitored partial email address serialiser’s field validators run

### DIFF
--- a/mtp_api/apps/security/migrations/0036_monitoredpartialemailaddress.py
+++ b/mtp_api/apps/security/migrations/0036_monitoredpartialemailaddress.py
@@ -21,7 +21,8 @@ class Migration(migrations.Migration):
                  model_utils.fields.AutoLastModifiedField(default=now, editable=False, verbose_name='modified')),
                 ('keyword',
                  models.CharField(max_length=255, unique=True,
-                                             validators=[django.core.validators.MinLengthValidator(3)])),
+                                  error_messages={'unique': 'Keyword already exists.'},
+                                  validators=[django.core.validators.MinLengthValidator(3)])),
             ],
             options={
                 'ordering': ('keyword',),

--- a/mtp_api/apps/security/models.py
+++ b/mtp_api/apps/security/models.py
@@ -289,7 +289,9 @@ class SearchFilter(models.Model):
 
 
 class MonitoredPartialEmailAddress(TimeStampedModel):
-    keyword = models.CharField(max_length=255, unique=True, validators=[MinLengthValidator(3)])
+    keyword = models.CharField(max_length=255, unique=True, validators=[MinLengthValidator(3)], error_messages={
+        'unique': _('Keyword already exists.'),
+    })
 
     objects = MonitoredPartialEmailAddressManager()
 

--- a/mtp_api/apps/security/tests/test_views/test_monitored_partial_email_address_views.py
+++ b/mtp_api/apps/security/tests/test_views/test_monitored_partial_email_address_views.py
@@ -48,6 +48,28 @@ class MonitoredPartialEmailAddressTestCase(APITestCase, AuthTestCaseMixin):
         MonitoredPartialEmailAddress.objects.get(keyword='mouse')
         self.assertFalse(MonitoredPartialEmailAddress.objects.filter(keyword='Mouse').exists())
 
+    def test_invalid_create(self):
+        response = self.client.post(
+            self.list_url(),
+            data='ab',
+            format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(self.fiu_user),
+        )
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        response_data = response.json()
+        self.assertIn('keyword', response_data)
+
+    def test_nonunique_create(self):
+        response = self.client.post(
+            self.list_url(),
+            data='CAT',
+            format='json',
+            HTTP_AUTHORIZATION=self.get_http_authorization_for_user(self.fiu_user),
+        )
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        response_data = response.json()
+        self.assertIn('keyword', response_data)
+
     def test_unauthorised_cannot_create(self):
         response = self.client.post(
             self.list_url(),

--- a/mtp_api/apps/security/tests/test_views/test_monitored_partial_email_address_views.py
+++ b/mtp_api/apps/security/tests/test_views/test_monitored_partial_email_address_views.py
@@ -45,7 +45,7 @@ class MonitoredPartialEmailAddressTestCase(APITestCase, AuthTestCaseMixin):
         )
         self.assertEqual(response.status_code, http_status.HTTP_201_CREATED)
         self.assertEqual(MonitoredPartialEmailAddress.objects.count(), 3)
-        MonitoredPartialEmailAddress.objects.get(keyword='mouse')
+        MonitoredPartialEmailAddress.objects.get(keyword='mouse')  # NB: serialiser lowers case
         self.assertFalse(MonitoredPartialEmailAddress.objects.filter(keyword='Mouse').exists())
 
     def test_invalid_create(self):


### PR DESCRIPTION
#769 used an inappropriate base serialiser class which did not validate the `keyword` field properly. Now, failing keyword uniqueness and length checks will return a 400 instead of 500