### PR TITLE
MTP-1980: Postgres upgrade to version 16.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 parameters:
   postgres-version:
     type: string
-    default: '14.3'
+    default: '14.10'
   kubectl-version:
     type: string
     default: v1.26.11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 parameters:
   postgres-version:
     type: string
-    default: '14.10'
+    default: '16.1'
   kubectl-version:
     type: string
     default: v1.26.11


### PR DESCRIPTION
Postgres 16.1 is deprecated and will be supported only until March 2024. 14.10 also include mitigations for several CVEs including CVE-2023-5869: https://www.postgresql.org/support/security/CVE-2023-5869/

See AWS Posgres release calendar:
https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html

NOTE: This doesn't upgrade any database, it will just run the tests on a PosgreSQL 16.1 in CI.