### PR TITLE
MTP-1931: Disable users who’ve not logged in for some time

### DIFF
--- a/mtp_api/apps/mtp_auth/management/commands/disable_inactive_users.py
+++ b/mtp_api/apps/mtp_auth/management/commands/disable_inactive_users.py
@@ -1,0 +1,50 @@
+from dateutil.relativedelta import relativedelta
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand, CommandError
+from django.db.models import Q
+from django.utils.timezone import now
+from oauth2_provider.models import Application
+
+from mtp_auth.constants import CASHBOOK_OAUTH_CLIENT_ID, BANK_ADMIN_OAUTH_CLIENT_ID, NOMS_OPS_OAUTH_CLIENT_ID
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """
+    Deactivate users who have not logged in for a while.
+    Only applies to regular users with access to particular apps.
+    """
+    help = __doc__.strip().splitlines()[0]
+
+    inactive_months = 3
+    applications = [CASHBOOK_OAUTH_CLIENT_ID, BANK_ADMIN_OAUTH_CLIENT_ID, NOMS_OPS_OAUTH_CLIENT_ID]
+
+    def handle(self, *args, **options):
+        verbosity = options['verbosity']
+
+        cutoff_date = now() - relativedelta(months=self.inactive_months)
+
+        applications = list(Application.objects.filter(client_id__in=self.applications).values_list('pk', flat=True))
+        if len(applications) != len(self.applications):
+            raise CommandError('Could not find all oauth applications')
+
+        if verbosity > 0:
+            self.stderr.write(f'Looking for users who’ve not logged in since {cutoff_date}')
+
+        users = User.objects.filter(
+            is_active=True,
+            is_staff=False,
+            is_superuser=False,
+            applicationusermapping__application__in=applications,
+        ).filter(
+            # last login was a long time ago
+            Q(last_login__lt=cutoff_date) |
+            # or never logged in but joined a long time ago
+            Q(last_login__isnull=True) & Q(date_joined__lt=cutoff_date)
+        ).distinct('username')
+        for user in users:
+            if verbosity > 0:
+                self.stderr.write(f'Deactivating {user.username}')
+            user.is_active = False
+            user.save()

--- a/mtp_api/apps/mtp_auth/tests/test_disable_inactive_users.py
+++ b/mtp_api/apps/mtp_auth/tests/test_disable_inactive_users.py
@@ -1,8 +1,9 @@
 import datetime
 
+from dateutil.relativedelta import relativedelta
 from django.core.management import call_command, CommandError
 from django.test import TestCase
-from django.utils.timezone import make_aware
+from django.utils.timezone import make_aware, now
 from oauth2_provider.models import Application
 
 from core.tests.utils import make_test_users, make_test_user_admins, create_super_admin
@@ -20,7 +21,7 @@ class DisableInactiveUsersTestCase(TestCase):
         self.users = make_test_users()
         self.user_admins = make_test_user_admins()
 
-    def assertInactiveUsernames(self, usernames: list[str]):  # noqa: N802
+    def assertInactiveUsernames(self, *usernames):  # noqa: N802
         self.assertSequenceEqual(
             User.objects.filter(is_active=False).order_by('username').values_list('username', flat=True),
             sorted(usernames),
@@ -35,45 +36,84 @@ class DisableInactiveUsersTestCase(TestCase):
 
     def test_users_who_have_not_logged_in_for_a_while_are_disabled(self):
         prison_clerk = self.users['prison_clerks'][0]
+        prison_clerk_user_admin = self.user_admins['prison_clerk_uas'][0]
         bank_admin = self.users['bank_admins'][0]
         security_staff = self.users['security_staff'][0]
 
         self.make_user_old(prison_clerk)
+        self.make_user_old(prison_clerk_user_admin)
         self.make_user_old(bank_admin)
         self.make_user_old(security_staff)
 
         self.assertFalse(User.objects.filter(is_active=False).exists())
         call_command('disable_inactive_users', verbosity=0)
-        self.assertInactiveUsernames([prison_clerk.username, bank_admin.username, security_staff.username])
+        self.assertInactiveUsernames(
+            prison_clerk.username,
+            prison_clerk_user_admin.username,
+            bank_admin.username,
+            security_staff.username,
+        )
 
     def test_users_who_have_never_logged_in_are_disabled(self):
         prison_clerk = self.users['prison_clerks'][0]
         refund_bank_admin = self.users['refund_bank_admins'][0]
+        bank_admin_user_admin = self.user_admins['bank_admin_uas'][0]
         fiu_user = self.users['security_fiu_users'][0]
 
         self.make_user_old(prison_clerk, last_login=None)
         self.make_user_old(refund_bank_admin, last_login=None)
+        self.make_user_old(bank_admin_user_admin, last_login=None)
         self.make_user_old(fiu_user, last_login=None)
 
         self.assertFalse(User.objects.filter(is_active=False).exists())
         call_command('disable_inactive_users', verbosity=0)
-        self.assertInactiveUsernames([prison_clerk.username, refund_bank_admin.username, fiu_user.username])
+        self.assertInactiveUsernames(
+            prison_clerk.username,
+            refund_bank_admin.username,
+            bank_admin_user_admin.username,
+            fiu_user.username,
+        )
+
+    def test_user_admins_are_given_longer_to_become_inactive(self):
+        prison_clerk_user_admin = self.user_admins['prison_clerk_uas'][0]  # user admin
+        bank_admin_user_admin = self.user_admins['bank_admin_uas'][0]  # user admin
+        security_staff = self.users['security_staff'][0]  # not a user admin
+
+        # old enough for a normal user to be deactivated, but not user admins
+        date_joined = now() - relativedelta(months=5)
+        last_login = now() - relativedelta(months=4)
+
+        self.make_user_old(prison_clerk_user_admin, date_joined=date_joined, last_login=last_login)
+        self.make_user_old(bank_admin_user_admin, date_joined=date_joined, last_login=None)
+        self.make_user_old(security_staff, date_joined=date_joined, last_login=last_login)
+
+        self.assertFalse(User.objects.filter(is_active=False).exists())
+        call_command('disable_inactive_users', verbosity=0)
+        self.assertInactiveUsernames(security_staff.username)
 
     def test_already_inactive_users_are_ignored(self):
         prison_clerk = self.users['prison_clerks'][1]
         disbursement_bank_admin = self.users['disbursement_bank_admins'][0]
         prisoner_location_admin = self.users['prisoner_location_admins'][0]
+        prisoner_location_user_admin = self.user_admins['prisoner_location_uas'][0]
 
         self.make_user_old(prison_clerk, is_active=False)
         self.make_user_old(disbursement_bank_admin, is_active=False)
         self.make_user_old(prisoner_location_admin, is_active=False)
+        self.make_user_old(prisoner_location_user_admin, is_active=False)
 
         self.assertInactiveUsernames(
-            [prison_clerk.username, disbursement_bank_admin.username, prisoner_location_admin.username],
+            prison_clerk.username,
+            disbursement_bank_admin.username,
+            prisoner_location_admin.username,
+            prisoner_location_user_admin.username,
         )
         call_command('disable_inactive_users', verbosity=0)
         self.assertInactiveUsernames(
-            [prison_clerk.username, disbursement_bank_admin.username, prisoner_location_admin.username],
+            prison_clerk.username,
+            disbursement_bank_admin.username,
+            prisoner_location_admin.username,
+            prisoner_location_user_admin.username,
         )
 
     def test_inactive_superusers_are_ignored(self):
@@ -88,8 +128,10 @@ class DisableInactiveUsersTestCase(TestCase):
     def test_inactive_staff_are_ignored(self):
         fiu_admin = self.user_admins['security_fiu_uas'][0]
 
-        self.make_user_old(fiu_admin, is_staff=True)  # upgrade user to allow access to django admin
+        # upgrade user to allow access to django admin
+        self.make_user_old(fiu_admin, is_staff=True)
 
+        self.assertFalse(User.objects.filter(is_active=False).exists())
         call_command('disable_inactive_users', verbosity=0)
         self.assertFalse(User.objects.filter(is_active=False).exists())
 
@@ -106,6 +148,7 @@ class DisableInactiveUsersTestCase(TestCase):
         User.objects.all().delete()
         Application.objects.all().delete()
 
+        self.assertFalse(User.objects.filter(is_active=False).exists())
         with self.assertRaises(CommandError):
             call_command('disable_inactive_users', verbosity=0)
         self.assertFalse(User.objects.filter(is_active=False).exists())

--- a/mtp_api/apps/mtp_auth/tests/test_disable_inactive_users.py
+++ b/mtp_api/apps/mtp_auth/tests/test_disable_inactive_users.py
@@ -1,0 +1,150 @@
+import datetime
+
+from django.core.management import call_command, CommandError
+from django.test import TestCase
+from django.utils.timezone import make_aware
+from oauth2_provider.models import Application
+
+from core.tests.utils import make_test_users, make_test_user_admins, create_super_admin
+from mtp_auth.management.commands.disable_inactive_users import User
+
+
+class DisableInactiveUsersTestCase(TestCase):
+    fixtures = ['initial_types.json', 'test_prisons.json', 'initial_groups.json']
+
+    def setUp(self):
+        super().setUp()
+        self.users = make_test_users()
+
+    def assertInactiveUsernames(self, usernames: list[str]):  # noqa: N802
+        self.assertSequenceEqual(
+            User.objects.filter(is_active=False).order_by('username').values_list('username', flat=True),
+            sorted(usernames),
+        )
+
+    def test_users_who_have_not_logged_in_for_a_while_are_disabled(self):
+        prison_clerk = self.users['prison_clerks'][0]
+        bank_admin = self.users['bank_admins'][0]
+        security_staff = self.users['security_staff'][0]
+
+        date_joined = make_aware(datetime.datetime(2023, 2, 8, 12))
+        last_login = make_aware(datetime.datetime(2023, 4, 10, 11))
+
+        def set_old_last_login(user):
+            user.date_joined = date_joined
+            user.last_login = last_login
+            user.save()
+
+        set_old_last_login(prison_clerk)
+        set_old_last_login(bank_admin)
+        set_old_last_login(security_staff)
+
+        self.assertFalse(User.objects.filter(is_active=False).exists())
+        call_command('disable_inactive_users', verbosity=0)
+        self.assertInactiveUsernames([prison_clerk.username, bank_admin.username, security_staff.username])
+
+    def test_users_who_have_never_logged_in_are_disabled(self):
+        prison_clerk = self.users['prison_clerks'][0]
+        refund_bank_admin = self.users['refund_bank_admins'][0]
+        fiu_user = self.users['security_fiu_users'][0]
+
+        date_joined = make_aware(datetime.datetime(2023, 2, 8, 12))
+
+        def set_unused_old_account(user):
+            user.date_joined = date_joined
+            user.last_login = None
+            user.save()
+
+        set_unused_old_account(prison_clerk)
+        set_unused_old_account(refund_bank_admin)
+        set_unused_old_account(fiu_user)
+
+        self.assertFalse(User.objects.filter(is_active=False).exists())
+        call_command('disable_inactive_users', verbosity=0)
+        self.assertInactiveUsernames([prison_clerk.username, refund_bank_admin.username, fiu_user.username])
+
+    def test_already_inactive_users_are_ignored(self):
+        prison_clerk = self.users['prison_clerks'][1]
+        disbursement_bank_admin = self.users['disbursement_bank_admins'][0]
+        prisoner_location_admin = self.users['prisoner_location_admins'][0]
+
+        date_joined = make_aware(datetime.datetime(2023, 2, 8, 12))
+        last_login = make_aware(datetime.datetime(2023, 4, 10, 11))
+
+        def set_already_inactive(user):
+            user.date_joined = date_joined
+            user.last_login = last_login
+            user.is_active = False
+            user.save()
+
+        set_already_inactive(prison_clerk)
+        set_already_inactive(disbursement_bank_admin)
+        set_already_inactive(prisoner_location_admin)
+
+        self.assertInactiveUsernames(
+            [prison_clerk.username, disbursement_bank_admin.username, prisoner_location_admin.username],
+        )
+        call_command('disable_inactive_users', verbosity=0)
+        self.assertInactiveUsernames(
+            [prison_clerk.username, disbursement_bank_admin.username, prisoner_location_admin.username],
+        )
+
+    def test_inactive_superusers_are_ignored(self):
+        create_super_admin()
+
+        date_joined = make_aware(datetime.datetime(2023, 2, 8, 12))
+        last_login = make_aware(datetime.datetime(2023, 4, 10, 11))
+
+        def set_old_last_login(user):
+            user.date_joined = date_joined
+            user.last_login = last_login
+            user.save()
+
+        set_old_last_login(User.objects.get(username='admin'))
+
+        self.assertFalse(User.objects.filter(is_active=False).exists())
+        call_command('disable_inactive_users', verbosity=0)
+        self.assertFalse(User.objects.filter(is_active=False).exists())
+
+    def test_inactive_staff_are_ignored(self):
+        user_admins = make_test_user_admins()
+        fiu_admin = user_admins['security_fiu_uas'][0]
+
+        date_joined = make_aware(datetime.datetime(2023, 2, 8, 12))
+        last_login = make_aware(datetime.datetime(2023, 4, 10, 11))
+
+        def set_old_last_login(user):
+            user.date_joined = date_joined
+            user.last_login = last_login
+            user.is_staff = True  # upgrade user to allow access to django admin
+            user.save()
+
+        set_old_last_login(fiu_admin)
+
+        call_command('disable_inactive_users', verbosity=0)
+        self.assertFalse(User.objects.filter(is_active=False).exists())
+
+    def test_inactive_users_of_other_apps_are_ignored(self):
+        send_money_user = self.users['send_money_users'][0]
+
+        date_joined = make_aware(datetime.datetime(2023, 2, 8, 12))
+        last_login = make_aware(datetime.datetime(2023, 4, 10, 11))
+
+        def set_old_last_login(user):
+            user.date_joined = date_joined
+            user.last_login = last_login
+            user.save()
+
+        set_old_last_login(send_money_user)
+
+        self.assertFalse(User.objects.filter(is_active=False).exists())
+        call_command('disable_inactive_users', verbosity=0)
+        self.assertFalse(User.objects.filter(is_active=False).exists())
+
+    def test_error_if_missing_applications(self):
+        User.objects.all().delete()
+        Application.objects.all().delete()
+
+        with self.assertRaises(CommandError):
+            call_command('disable_inactive_users', verbosity=0)
+        self.assertFalse(User.objects.filter(is_active=False).exists())

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,7 @@ drf-nested-routers~=0.93.5
 crontab~=1.0
 xlrd~=2.0.1
 reportlab>=4.1,<4.2
+python-dateutil>=2.9
 numpy>=1.26,<2
 scipy>=1.11,<2
 openpyxl~=3.1


### PR DESCRIPTION
Users who have not logged in for 3 months count are set as inactive by a new management command.
Applies only to non-staff (i.e. those that cannot log into Django admin) and non-superadmin users of these mtp apps: cashbook, bank-admin & noms-ops