### PR TITLE
Django 5.2

### DIFF
--- a/mtp_api/apps/core/views.py
+++ b/mtp_api/apps/core/views.py
@@ -247,13 +247,13 @@ class RecreateTestDataView(AdminViewMixin, FormView):
         output.seek(0)
         command_output = output.read()
 
-        LogEntry.objects.log_action(
+        LogEntry.objects.create(
             user_id=self.request.user.pk,
-            content_type_id=None, object_id=None,
             object_repr=_('Data reset to %(scenario)s scenario') % {
                 'scenario': scenario
             },
             action_flag=CHANGE_LOG_ENTRY,
+            change_message='',
         )
         logger.info('User "%(username)s" reset data for testing using "%(scenario)s" scenario', {
             'username': self.request.user.username,

--- a/mtp_api/apps/credit/tests/test_base.py
+++ b/mtp_api/apps/credit/tests/test_base.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time
+from datetime import datetime, time, timezone as tz
 
 from django.db import models
 from django.utils import timezone
@@ -96,7 +96,7 @@ class BaseCreditViewTestCase(AuthTestCaseMixin, APITestCase):
                     c
                     for c in credits
                     if c.received_at
-                    and c.received_at < datetime.combine(timezone.now().date(), time.min).replace(tzinfo=timezone.utc)
+                    and c.received_at < datetime.combine(timezone.now().date(), time.min).replace(tzinfo=tz.utc)
                 ]
             managing_prisons = list(PrisonUserMapping.objects.get_prison_set_for_user(logged_in_user))
             return [c for c in credits if c.prison in managing_prisons]

--- a/mtp_api/apps/credit/tests/test_views/test_credit_list/test_credit_list_with_recieved_at_filter.py
+++ b/mtp_api/apps/credit/tests/test_views/test_credit_list/test_credit_list_with_recieved_at_filter.py
@@ -1,7 +1,7 @@
 import datetime
+from datetime import timezone
 
 from django.utils.dateformat import format as format_date
-from django.utils import timezone
 
 from credit.tests.test_views.test_credit_list import CreditListTestCase
 

--- a/mtp_api/apps/mtp_auth/admin.py
+++ b/mtp_api/apps/mtp_auth/admin.py
@@ -105,11 +105,13 @@ class UserAdmin(DjangoUserAdmin):
             attempts = FailedLoginAttempt.objects.filter(user=instance)
             if attempts.count():
                 attempts.delete()
-                LogEntry.objects.log_action(
+                LogEntry.objects.create(
                     user_id=request.user.pk,
-                    content_type_id=get_content_type_for_model(instance).pk, object_id=instance.pk,
+                    content_type_id=get_content_type_for_model(instance).pk,
+                    object_id=str(instance.pk),
                     object_repr=_('Remove lockouts'),
                     action_flag=CHANGE_LOG_ENTRY,
+                    change_message='',
                 )
                 accounts.append(instance)
         if accounts:

--- a/mtp_api/apps/mtp_auth/views.py
+++ b/mtp_api/apps/mtp_auth/views.py
@@ -507,14 +507,15 @@ class AccountRequestViewSet(viewsets.ModelViewSet):
                 staff_email=True,
             )
 
-        LogEntry.objects.log_action(
+        LogEntry.objects.create(
             user_id=request.user.pk,
             content_type_id=get_content_type_for_model(user).pk,
-            object_id=user.pk,
+            object_id=str(user.pk),
             object_repr=gettext('Accepted account request for %(username)s') % {
                 'username': user.username,
             },
             action_flag=CHANGE_LOG_ENTRY,
+            change_message='',
         )
 
         instance.delete()
@@ -529,14 +530,15 @@ class AccountRequestViewSet(viewsets.ModelViewSet):
             },
             staff_email=True,
         )
-        LogEntry.objects.log_action(
+        LogEntry.objects.create(
             user_id=self.request.user.pk,
             content_type_id=get_content_type_for_model(instance).pk,
-            object_id=instance.pk,
+            object_id=str(instance.pk),
             object_repr=gettext('Declined account request from %(username)s') % {
                 'username': instance.username,
             },
             action_flag=DELETION_LOG_ENTRY,
+            change_message='',
         )
         super().perform_destroy(instance)
 

--- a/mtp_api/apps/performance/views.py
+++ b/mtp_api/apps/performance/views.py
@@ -57,14 +57,14 @@ class DigitalTakeupUploadView(AdminViewMixin, FormView):
 
         self.update_performance_data(form.date)
 
-        LogEntry.objects.log_action(
+        LogEntry.objects.create(
             user_id=self.request.user.pk,
-            content_type_id=None, object_id=None,
             object_repr=self.save_message % {
                 'date': date_format(form.date, 'DATE_FORMAT'),
                 'prison_count': len(form.credits_by_prison),
             },
             action_flag=ADDITION_LOG_ENTRY,
+            change_message='',
         )
         messages.success(self.request, self.save_message % {
             'date': date_format(form.date, 'DATE_FORMAT'),
@@ -158,11 +158,11 @@ class UserSatisfactionUploadView(AdminViewMixin, FormView):
         message = _('Saved user satisfaction records for %(count)d days') % {
             'count': len(form.records),
         }
-        LogEntry.objects.log_action(
+        LogEntry.objects.create(
             user_id=self.request.user.pk,
-            content_type_id=None, object_id=None,
             object_repr=message,
             action_flag=ADDITION_LOG_ENTRY,
+            change_message='',
         )
         messages.success(self.request, message)
         return super().form_valid(form)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=19.1.0
+money-to-prisoners-common~=20.0.0
 
 psycopg2~=2.9.9
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=19.1.0
+money-to-prisoners-common[testing]~=20.0.0
 
 -r base.txt
 


### PR DESCRIPTION
- use newest version of mtp-common which bumps Django to version 5.2
- removed yet another use of `django.utils.timezone.utc`
- removed deprecated method `LogEntryManager.log_action()` method usage (https://github.com/ministryofjustice/money-to-prisoners-api/pull/825/commits/ea0f0e7f9d43c11a946a4f290eabf33b28bd1de8)

Here an example of some of the `LogEntry` records created locally while playing with the Django admin interface:

<img width="1456" alt="Screenshot 2025-04-09 at 16 38 04" src="https://github.com/user-attachments/assets/467d38a2-4dec-4455-a8b3-8245fccba587" />