### PR TITLE
JIRA-1694 Fix govuk-frontend SCSS import in performance dashboard

### DIFF
--- a/mtp_api/assets-src/stylesheets/performance-dashboard.scss
+++ b/mtp_api/assets-src/stylesheets/performance-dashboard.scss
@@ -1,4 +1,5 @@
-@import 'govuk-frontend/dist/govuk/settings/all';
+@import 'govuk-frontend/dist/govuk/settings';
+@import 'govuk-frontend/dist/govuk/helpers';
 
 body {
   padding: 30px 100px;


### PR DESCRIPTION
## Problem

The Docker build fails at the SCSS asset step:

```
Failed building mtp_api/assets-src/stylesheets/performance-dashboard.scss:
  Error: File to import not found or unreadable: govuk-frontend/dist/govuk/settings/all
  >> @import 'govuk-frontend/dist/govuk/settings/all';
```

`performance-dashboard.scss` is the only API stylesheet that imports govuk-frontend directly, and its import path was last set in Jan 2024. govuk-frontend 6.x **removed the `settings/all` entry point** and **moved the `govuk-colour()` function into `helpers`**, so the old import no longer resolves. This surfaced now because the build performs a clean `npm install` (the requirements change in #869 busted the Docker layer cache) which pulls the current govuk-frontend `~6.1` fed by `money-to-prisoners-common`.

This is a latent issue independent of any dependency PR — it affects `main` on any clean rebuild.

## Fix

Import `settings` and `helpers` instead of the removed `settings/all`:

```scss
@import 'govuk-frontend/dist/govuk/settings';
@import 'govuk-frontend/dist/govuk/helpers';
```

`helpers` provides the `govuk-colour()` function the file uses; `settings` provides the colour palette.

## Verification

Reproduced locally against `govuk-frontend@6.1.0`: the old import errors with "file not found"; the new imports compile cleanly and `govuk-colour()` resolves (~74 lines of CSS — no bloat from pulling the full govuk bundle).

Deprecation warnings remain for legacy colour names (`light-purple`, etc.); these are non-fatal and left unchanged to preserve the dashboard's appearance.

## Note

Combined-dependency PR #869 will keep failing its build until this lands on `main`; once merged, re-running #869 should go green.